### PR TITLE
Add prototype device schema and interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+# All files
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,projitems,shproj,bonsai}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs}]
+# Organize usings
+dotnet_sort_system_directives_first = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
+
 desktop.ini
+
+# Visual studio files
+.vs
+.suo
+.nuget
+bin
+obj
+Debug
+packages
+*.componentinfo.xml

--- a/Generators/Generators.csproj
+++ b/Generators/Generators.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>Harp.Behavior</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DeviceMetadata>..\device.yml</DeviceMetadata>
+    <IOMetadata>..\ios.yml</IOMetadata>
+  </PropertyGroup>
+  <PropertyGroup>
+    <InterfacePath>..\Interface\Harp.Behavior</InterfacePath>
+    <FirmwarePath>..\Firmware\Harp.Behavior</FirmwarePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Harp.Generators" Version="0.1.0-build032704" GeneratePathProperty="true" />
+  </ItemGroup>
+  <Target Name="TextTransform" BeforeTargets="AfterBuild">
+    <PropertyGroup>
+      <InterfaceFlags>-p:MetadataPath=$(DeviceMetadata) -p:Namespace=$(RootNamespace) -P=$(TargetDir)</InterfaceFlags>
+      <FirmwareFlags>-p:RegisterMetadataPath=$(DeviceMetadata) -p:IOMetadataPath=$(IOMetadata) -P=$(TargetDir)</FirmwareFlags>
+    </PropertyGroup>
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(DeviceMetadata)) And $([System.String]::new('%(Content.Link)').EndsWith('Device.tt'))"
+          Command="t4 %(Content.Identity) $(InterfaceFlags) -o=$(InterfacePath)\%(Content.Link)" />
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(IOMetadata)) And '%(Content.Link)' == 'Firmware.tt'"
+          Command="t4 %(Content.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app_ios_and_regs.h" />
+  </Target>
+</Project>

--- a/Interface/Harp.Behavior.sln
+++ b/Interface/Harp.Behavior.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{D2F2777C-C194-4D33-8CC0-13E6066E2CD2}") = "Harp.Behavior", "Harp.Behavior\Harp.Behavior.csproj", "{B1EFE0D6-C68F-470F-9A48-380E18375BD1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B1EFE0D6-C68F-470F-9A48-380E18375BD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1EFE0D6-C68F-470F-9A48-380E18375BD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1EFE0D6-C68F-470F-9A48-380E18375BD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1EFE0D6-C68F-470F-9A48-380E18375BD1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {493F9445-36D2-4F33-8CD5-9236142E676D}
+	EndGlobalSection
+EndGlobal

--- a/Interface/Harp.Behavior/AsyncDevice.Generated.cs
+++ b/Interface/Harp.Behavior/AsyncDevice.Generated.cs
@@ -1,0 +1,2471 @@
+using Bonsai.Harp;
+using System.Threading.Tasks;
+
+namespace Harp.Behavior
+{
+    /// <inheritdoc/>
+    public partial class Device
+    {
+        /// <summary>
+        /// Initializes a new instance of the asynchronous API to configure and interface
+        /// with Behavior devices on the specified serial port.
+        /// </summary>
+        /// <param name="portName">
+        /// The name of the serial port used to communicate with the Harp device.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous initialization operation. The value of
+        /// the <see cref="Task{TResult}.Result"/> parameter contains a new instance of
+        /// the <see cref="AsyncDevice"/> class.
+        /// </returns>
+        public static async Task<AsyncDevice> CreateAsync(string portName)
+        {
+            var device = new AsyncDevice(portName);
+            var whoAmI = await device.ReadWhoAmIAsync();
+            if (whoAmI != Device.WhoAmI)
+            {
+                var errorMessage = string.Format(
+                    "The device ID {1} on {0} was unexpected. Check whether a Behavior device is connected to the specified serial port.",
+                    portName, whoAmI);
+                throw new HarpException(errorMessage);
+            }
+
+            return device;
+        }
+    }
+
+    /// <summary>
+    /// Represents an asynchronous API to configure and interface with Behavior devices.
+    /// </summary>
+    public partial class AsyncDevice : Bonsai.Harp.AsyncDevice
+    {
+        internal AsyncDevice(string portName)
+            : base(portName)
+        {
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDigitalInput register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<DigitalInputs> ReadPortDigitalInputAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDigitalInput.Address));
+            return PortDigitalInput.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDigitalInput register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<DigitalInputs>> ReadTimestampedPortDigitalInputAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDigitalInput.Address));
+            return PortDigitalInput.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the OutputSet register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<DigitalOutputs> ReadOutputSetAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputSet.Address));
+            return OutputSet.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the OutputSet register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<DigitalOutputs>> ReadTimestampedOutputSetAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputSet.Address));
+            return OutputSet.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the OutputSet register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteOutputSetAsync(DigitalOutputs value)
+        {
+            var request = OutputSet.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the OutputClear register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<DigitalOutputs> ReadOutputClearAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputClear.Address));
+            return OutputClear.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the OutputClear register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<DigitalOutputs>> ReadTimestampedOutputClearAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputClear.Address));
+            return OutputClear.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the OutputClear register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteOutputClearAsync(DigitalOutputs value)
+        {
+            var request = OutputClear.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the OutputToggle register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<DigitalOutputs> ReadOutputToggleAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputToggle.Address));
+            return OutputToggle.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the OutputToggle register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<DigitalOutputs>> ReadTimestampedOutputToggleAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputToggle.Address));
+            return OutputToggle.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the OutputToggle register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteOutputToggleAsync(DigitalOutputs value)
+        {
+            var request = OutputToggle.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the OutputState register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<DigitalOutputs> ReadOutputStateAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputState.Address));
+            return OutputState.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the OutputState register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<DigitalOutputs>> ReadTimestampedOutputStateAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputState.Address));
+            return OutputState.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the OutputState register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteOutputStateAsync(DigitalOutputs value)
+        {
+            var request = OutputState.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDIOSet register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PortDigitalIOS> ReadPortDIOSetAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOSet.Address));
+            return PortDIOSet.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDIOSet register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PortDigitalIOS>> ReadTimestampedPortDIOSetAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOSet.Address));
+            return PortDIOSet.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PortDIOSet register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePortDIOSetAsync(PortDigitalIOS value)
+        {
+            var request = PortDIOSet.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDIOClear register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PortDigitalIOS> ReadPortDIOClearAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOClear.Address));
+            return PortDIOClear.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDIOClear register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PortDigitalIOS>> ReadTimestampedPortDIOClearAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOClear.Address));
+            return PortDIOClear.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PortDIOClear register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePortDIOClearAsync(PortDigitalIOS value)
+        {
+            var request = PortDIOClear.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDIOToggle register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PortDigitalIOS> ReadPortDIOToggleAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOToggle.Address));
+            return PortDIOToggle.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDIOToggle register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PortDigitalIOS>> ReadTimestampedPortDIOToggleAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOToggle.Address));
+            return PortDIOToggle.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PortDIOToggle register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePortDIOToggleAsync(PortDigitalIOS value)
+        {
+            var request = PortDIOToggle.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDIOState register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PortDigitalIOS> ReadPortDIOStateAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOState.Address));
+            return PortDIOState.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDIOState register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PortDigitalIOS>> ReadTimestampedPortDIOStateAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOState.Address));
+            return PortDIOState.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PortDIOState register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePortDIOStateAsync(PortDigitalIOS value)
+        {
+            var request = PortDIOState.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDIODirection register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PortDigitalIOS> ReadPortDIODirectionAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIODirection.Address));
+            return PortDIODirection.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDIODirection register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PortDigitalIOS>> ReadTimestampedPortDIODirectionAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIODirection.Address));
+            return PortDIODirection.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PortDIODirection register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePortDIODirectionAsync(PortDigitalIOS value)
+        {
+            var request = PortDIODirection.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PortDIOStateEvent register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PortDigitalIOS> ReadPortDIOStateEventAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOStateEvent.Address));
+            return PortDIOStateEvent.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PortDIOStateEvent register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PortDigitalIOS>> ReadTimestampedPortDIOStateEventAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PortDIOStateEvent.Address));
+            return PortDIOStateEvent.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the AnalogData register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<AnalogDataPayload> ReadAnalogDataAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadInt16(AnalogData.Address));
+            return AnalogData.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the AnalogData register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<AnalogDataPayload>> ReadTimestampedAnalogDataAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadInt16(AnalogData.Address));
+            return AnalogData.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the OutputPulseEnable register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<DigitalOutputs> ReadOutputPulseEnableAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputPulseEnable.Address));
+            return OutputPulseEnable.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the OutputPulseEnable register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<DigitalOutputs>> ReadTimestampedOutputPulseEnableAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(OutputPulseEnable.Address));
+            return OutputPulseEnable.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the OutputPulseEnable register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteOutputPulseEnableAsync(DigitalOutputs value)
+        {
+            var request = OutputPulseEnable.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDOPort0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDOPort0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDOPort0.Address));
+            return PulseDOPort0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDOPort0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDOPort0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDOPort0.Address));
+            return PulseDOPort0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDOPort0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDOPort0Async(ushort value)
+        {
+            var request = PulseDOPort0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDOPort1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDOPort1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDOPort1.Address));
+            return PulseDOPort1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDOPort1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDOPort1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDOPort1.Address));
+            return PulseDOPort1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDOPort1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDOPort1Async(ushort value)
+        {
+            var request = PulseDOPort1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDOPort2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDOPort2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDOPort2.Address));
+            return PulseDOPort2.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDOPort2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDOPort2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDOPort2.Address));
+            return PulseDOPort2.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDOPort2 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDOPort2Async(ushort value)
+        {
+            var request = PulseDOPort2.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseSupplyPort0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseSupplyPort0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseSupplyPort0.Address));
+            return PulseSupplyPort0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseSupplyPort0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseSupplyPort0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseSupplyPort0.Address));
+            return PulseSupplyPort0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseSupplyPort0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseSupplyPort0Async(ushort value)
+        {
+            var request = PulseSupplyPort0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseSupplyPort1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseSupplyPort1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseSupplyPort1.Address));
+            return PulseSupplyPort1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseSupplyPort1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseSupplyPort1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseSupplyPort1.Address));
+            return PulseSupplyPort1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseSupplyPort1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseSupplyPort1Async(ushort value)
+        {
+            var request = PulseSupplyPort1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseSupplyPort2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseSupplyPort2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseSupplyPort2.Address));
+            return PulseSupplyPort2.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseSupplyPort2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseSupplyPort2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseSupplyPort2.Address));
+            return PulseSupplyPort2.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseSupplyPort2 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseSupplyPort2Async(ushort value)
+        {
+            var request = PulseSupplyPort2.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseLed0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseLed0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseLed0.Address));
+            return PulseLed0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseLed0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseLed0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseLed0.Address));
+            return PulseLed0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseLed0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseLed0Async(ushort value)
+        {
+            var request = PulseLed0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseLed1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseLed1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseLed1.Address));
+            return PulseLed1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseLed1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseLed1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseLed1.Address));
+            return PulseLed1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseLed1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseLed1Async(ushort value)
+        {
+            var request = PulseLed1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseRgb0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseRgb0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseRgb0.Address));
+            return PulseRgb0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseRgb0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseRgb0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseRgb0.Address));
+            return PulseRgb0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseRgb0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseRgb0Async(ushort value)
+        {
+            var request = PulseRgb0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseRgb1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseRgb1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseRgb1.Address));
+            return PulseRgb1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseRgb1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseRgb1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseRgb1.Address));
+            return PulseRgb1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseRgb1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseRgb1Async(ushort value)
+        {
+            var request = PulseRgb1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDO0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDO0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO0.Address));
+            return PulseDO0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDO0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDO0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO0.Address));
+            return PulseDO0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDO0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDO0Async(ushort value)
+        {
+            var request = PulseDO0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDO1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDO1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO1.Address));
+            return PulseDO1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDO1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDO1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO1.Address));
+            return PulseDO1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDO1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDO1Async(ushort value)
+        {
+            var request = PulseDO1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDO2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDO2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO2.Address));
+            return PulseDO2.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDO2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDO2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO2.Address));
+            return PulseDO2.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDO2 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDO2Async(ushort value)
+        {
+            var request = PulseDO2.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PulseDO3 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPulseDO3Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO3.Address));
+            return PulseDO3.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PulseDO3 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPulseDO3Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PulseDO3.Address));
+            return PulseDO3.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PulseDO3 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePulseDO3Async(ushort value)
+        {
+            var request = PulseDO3.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmFrequencyDO0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPwmFrequencyDO0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO0.Address));
+            return PwmFrequencyDO0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmFrequencyDO0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPwmFrequencyDO0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO0.Address));
+            return PwmFrequencyDO0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmFrequencyDO0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmFrequencyDO0Async(ushort value)
+        {
+            var request = PwmFrequencyDO0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmFrequencyDO1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPwmFrequencyDO1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO1.Address));
+            return PwmFrequencyDO1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmFrequencyDO1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPwmFrequencyDO1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO1.Address));
+            return PwmFrequencyDO1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmFrequencyDO1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmFrequencyDO1Async(ushort value)
+        {
+            var request = PwmFrequencyDO1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmFrequencyDO2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPwmFrequencyDO2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO2.Address));
+            return PwmFrequencyDO2.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmFrequencyDO2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPwmFrequencyDO2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO2.Address));
+            return PwmFrequencyDO2.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmFrequencyDO2 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmFrequencyDO2Async(ushort value)
+        {
+            var request = PwmFrequencyDO2.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmFrequencyDO3 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadPwmFrequencyDO3Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO3.Address));
+            return PwmFrequencyDO3.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmFrequencyDO3 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedPwmFrequencyDO3Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(PwmFrequencyDO3.Address));
+            return PwmFrequencyDO3.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmFrequencyDO3 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmFrequencyDO3Async(ushort value)
+        {
+            var request = PwmFrequencyDO3.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmDutyCycleDO0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadPwmDutyCycleDO0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO0.Address));
+            return PwmDutyCycleDO0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmDutyCycleDO0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedPwmDutyCycleDO0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO0.Address));
+            return PwmDutyCycleDO0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmDutyCycleDO0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmDutyCycleDO0Async(byte value)
+        {
+            var request = PwmDutyCycleDO0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmDutyCycleDO1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadPwmDutyCycleDO1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO1.Address));
+            return PwmDutyCycleDO1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmDutyCycleDO1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedPwmDutyCycleDO1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO1.Address));
+            return PwmDutyCycleDO1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmDutyCycleDO1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmDutyCycleDO1Async(byte value)
+        {
+            var request = PwmDutyCycleDO1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmDutyCycleDO2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadPwmDutyCycleDO2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO2.Address));
+            return PwmDutyCycleDO2.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmDutyCycleDO2 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedPwmDutyCycleDO2Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO2.Address));
+            return PwmDutyCycleDO2.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmDutyCycleDO2 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmDutyCycleDO2Async(byte value)
+        {
+            var request = PwmDutyCycleDO2.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmDutyCycleDO3 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadPwmDutyCycleDO3Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO3.Address));
+            return PwmDutyCycleDO3.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmDutyCycleDO3 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedPwmDutyCycleDO3Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmDutyCycleDO3.Address));
+            return PwmDutyCycleDO3.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmDutyCycleDO3 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmDutyCycleDO3Async(byte value)
+        {
+            var request = PwmDutyCycleDO3.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmStart register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<PwmOutputs> ReadPwmStartAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmStart.Address));
+            return PwmStart.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmStart register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<PwmOutputs>> ReadTimestampedPwmStartAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmStart.Address));
+            return PwmStart.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmStart register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmStartAsync(PwmOutputs value)
+        {
+            var request = PwmStart.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PwmStop register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadPwmStopAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmStop.Address));
+            return PwmStop.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PwmStop register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedPwmStopAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PwmStop.Address));
+            return PwmStop.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PwmStop register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePwmStopAsync(byte value)
+        {
+            var request = PwmStop.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the RgbAll register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<RgbAllPayload> ReadRgbAllAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(RgbAll.Address));
+            return RgbAll.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the RgbAll register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<RgbAllPayload>> ReadTimestampedRgbAllAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(RgbAll.Address));
+            return RgbAll.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the RgbAll register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteRgbAllAsync(RgbAllPayload value)
+        {
+            var request = RgbAll.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Rgb0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<RgbPayload> ReadRgb0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Rgb0.Address));
+            return Rgb0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Rgb0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<RgbPayload>> ReadTimestampedRgb0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Rgb0.Address));
+            return Rgb0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Rgb0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteRgb0Async(RgbPayload value)
+        {
+            var request = Rgb0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Rgb1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<RgbPayload> ReadRgb1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Rgb1.Address));
+            return Rgb1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Rgb1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<RgbPayload>> ReadTimestampedRgb1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Rgb1.Address));
+            return Rgb1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Rgb1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteRgb1Async(RgbPayload value)
+        {
+            var request = Rgb1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Led0Current register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadLed0CurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led0Current.Address));
+            return Led0Current.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Led0Current register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedLed0CurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led0Current.Address));
+            return Led0Current.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Led0Current register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteLed0CurrentAsync(byte value)
+        {
+            var request = Led0Current.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Led1Current register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadLed1CurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led1Current.Address));
+            return Led1Current.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Led1Current register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedLed1CurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led1Current.Address));
+            return Led1Current.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Led1Current register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteLed1CurrentAsync(byte value)
+        {
+            var request = Led1Current.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Led0MaxCurrent register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadLed0MaxCurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led0MaxCurrent.Address));
+            return Led0MaxCurrent.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Led0MaxCurrent register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedLed0MaxCurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led0MaxCurrent.Address));
+            return Led0MaxCurrent.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Led0MaxCurrent register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteLed0MaxCurrentAsync(byte value)
+        {
+            var request = Led0MaxCurrent.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Led1MaxCurrent register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadLed1MaxCurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led1MaxCurrent.Address));
+            return Led1MaxCurrent.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Led1MaxCurrent register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedLed1MaxCurrentAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Led1MaxCurrent.Address));
+            return Led1MaxCurrent.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Led1MaxCurrent register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteLed1MaxCurrentAsync(byte value)
+        {
+            var request = Led1MaxCurrent.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the EventEnable register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<Events> ReadEventEnableAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EventEnable.Address));
+            return EventEnable.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the EventEnable register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<Events>> ReadTimestampedEventEnableAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EventEnable.Address));
+            return EventEnable.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the EventEnable register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteEventEnableAsync(Events value)
+        {
+            var request = EventEnable.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the StartCameras register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<CameraOutputs> ReadStartCamerasAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(StartCameras.Address));
+            return StartCameras.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the StartCameras register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<CameraOutputs>> ReadTimestampedStartCamerasAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(StartCameras.Address));
+            return StartCameras.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the StartCameras register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteStartCamerasAsync(CameraOutputs value)
+        {
+            var request = StartCameras.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the StopCameras register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<CameraOutputs> ReadStopCamerasAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(StopCameras.Address));
+            return StopCameras.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the StopCameras register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<CameraOutputs>> ReadTimestampedStopCamerasAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(StopCameras.Address));
+            return StopCameras.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the StopCameras register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteStopCamerasAsync(CameraOutputs value)
+        {
+            var request = StopCameras.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the EnableServos register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ServoOutputs> ReadEnableServosAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EnableServos.Address));
+            return EnableServos.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the EnableServos register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ServoOutputs>> ReadTimestampedEnableServosAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EnableServos.Address));
+            return EnableServos.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the EnableServos register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteEnableServosAsync(ServoOutputs value)
+        {
+            var request = EnableServos.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the DisableServos register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ServoOutputs> ReadDisableServosAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(DisableServos.Address));
+            return DisableServos.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the DisableServos register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ServoOutputs>> ReadTimestampedDisableServosAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(DisableServos.Address));
+            return DisableServos.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the DisableServos register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteDisableServosAsync(ServoOutputs value)
+        {
+            var request = DisableServos.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the EnableEncoders register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<EncoderInputs> ReadEnableEncodersAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EnableEncoders.Address));
+            return EnableEncoders.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the EnableEncoders register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<EncoderInputs>> ReadTimestampedEnableEncodersAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EnableEncoders.Address));
+            return EnableEncoders.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the EnableEncoders register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteEnableEncodersAsync(EncoderInputs value)
+        {
+            var request = EnableEncoders.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Camera0Frame register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<FrameAcquired> ReadCamera0FrameAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Camera0Frame.Address));
+            return Camera0Frame.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Camera0Frame register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<FrameAcquired>> ReadTimestampedCamera0FrameAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Camera0Frame.Address));
+            return Camera0Frame.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Camera0Frequency register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadCamera0FrequencyAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(Camera0Frequency.Address));
+            return Camera0Frequency.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Camera0Frequency register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedCamera0FrequencyAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(Camera0Frequency.Address));
+            return Camera0Frequency.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Camera0Frequency register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteCamera0FrequencyAsync(ushort value)
+        {
+            var request = Camera0Frequency.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Camera1Frame register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<FrameAcquired> ReadCamera1FrameAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Camera1Frame.Address));
+            return Camera1Frame.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Camera1Frame register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<FrameAcquired>> ReadTimestampedCamera1FrameAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Camera1Frame.Address));
+            return Camera1Frame.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Camera1Frequency register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadCamera1FrequencyAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(Camera1Frequency.Address));
+            return Camera1Frequency.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Camera1Frequency register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedCamera1FrequencyAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(Camera1Frequency.Address));
+            return Camera1Frequency.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Camera1Frequency register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteCamera1FrequencyAsync(ushort value)
+        {
+            var request = Camera1Frequency.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the ServoMotor2Period register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadServoMotor2PeriodAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor2Period.Address));
+            return ServoMotor2Period.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the ServoMotor2Period register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedServoMotor2PeriodAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor2Period.Address));
+            return ServoMotor2Period.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the ServoMotor2Period register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteServoMotor2PeriodAsync(ushort value)
+        {
+            var request = ServoMotor2Period.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the ServoMotor2Pulse register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadServoMotor2PulseAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor2Pulse.Address));
+            return ServoMotor2Pulse.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the ServoMotor2Pulse register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedServoMotor2PulseAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor2Pulse.Address));
+            return ServoMotor2Pulse.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the ServoMotor2Pulse register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteServoMotor2PulseAsync(ushort value)
+        {
+            var request = ServoMotor2Pulse.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the ServoMotor3Period register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadServoMotor3PeriodAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor3Period.Address));
+            return ServoMotor3Period.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the ServoMotor3Period register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedServoMotor3PeriodAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor3Period.Address));
+            return ServoMotor3Period.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the ServoMotor3Period register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteServoMotor3PeriodAsync(ushort value)
+        {
+            var request = ServoMotor3Period.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the ServoMotor3Pulse register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadServoMotor3PulseAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor3Pulse.Address));
+            return ServoMotor3Pulse.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the ServoMotor3Pulse register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedServoMotor3PulseAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(ServoMotor3Pulse.Address));
+            return ServoMotor3Pulse.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the ServoMotor3Pulse register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteServoMotor3PulseAsync(ushort value)
+        {
+            var request = ServoMotor3Pulse.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the EncoderReset register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<EncoderInputs> ReadEncoderResetAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EncoderReset.Address));
+            return EncoderReset.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the EncoderReset register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<EncoderInputs>> ReadTimestampedEncoderResetAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EncoderReset.Address));
+            return EncoderReset.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the EncoderReset register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteEncoderResetAsync(EncoderInputs value)
+        {
+            var request = EncoderReset.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the EnableSerialTimestamp register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadEnableSerialTimestampAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EnableSerialTimestamp.Address));
+            return EnableSerialTimestamp.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the EnableSerialTimestamp register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedEnableSerialTimestampAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EnableSerialTimestamp.Address));
+            return EnableSerialTimestamp.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the EnableSerialTimestamp register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteEnableSerialTimestampAsync(byte value)
+        {
+            var request = EnableSerialTimestamp.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the MimicPort0IR register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<MimicOutput> ReadMimicPort0IRAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort0IR.Address));
+            return MimicPort0IR.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the MimicPort0IR register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<MimicOutput>> ReadTimestampedMimicPort0IRAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort0IR.Address));
+            return MimicPort0IR.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the MimicPort0IR register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteMimicPort0IRAsync(MimicOutput value)
+        {
+            var request = MimicPort0IR.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the MimicPort1IR register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<MimicOutput> ReadMimicPort1IRAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort1IR.Address));
+            return MimicPort1IR.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the MimicPort1IR register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<MimicOutput>> ReadTimestampedMimicPort1IRAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort1IR.Address));
+            return MimicPort1IR.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the MimicPort1IR register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteMimicPort1IRAsync(MimicOutput value)
+        {
+            var request = MimicPort1IR.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the MimicPort2IR register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<MimicOutput> ReadMimicPort2IRAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort2IR.Address));
+            return MimicPort2IR.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the MimicPort2IR register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<MimicOutput>> ReadTimestampedMimicPort2IRAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort2IR.Address));
+            return MimicPort2IR.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the MimicPort2IR register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteMimicPort2IRAsync(MimicOutput value)
+        {
+            var request = MimicPort2IR.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the MimicPort0Valve register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<MimicOutput> ReadMimicPort0ValveAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort0Valve.Address));
+            return MimicPort0Valve.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the MimicPort0Valve register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<MimicOutput>> ReadTimestampedMimicPort0ValveAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort0Valve.Address));
+            return MimicPort0Valve.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the MimicPort0Valve register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteMimicPort0ValveAsync(MimicOutput value)
+        {
+            var request = MimicPort0Valve.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the MimicPort1Valve register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<MimicOutput> ReadMimicPort1ValveAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort1Valve.Address));
+            return MimicPort1Valve.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the MimicPort1Valve register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<MimicOutput>> ReadTimestampedMimicPort1ValveAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort1Valve.Address));
+            return MimicPort1Valve.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the MimicPort1Valve register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteMimicPort1ValveAsync(MimicOutput value)
+        {
+            var request = MimicPort1Valve.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the MimicPort2Valve register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<MimicOutput> ReadMimicPort2ValveAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort2Valve.Address));
+            return MimicPort2Valve.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the MimicPort2Valve register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<MimicOutput>> ReadTimestampedMimicPort2ValveAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(MimicPort2Valve.Address));
+            return MimicPort2Valve.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the MimicPort2Valve register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteMimicPort2ValveAsync(MimicOutput value)
+        {
+            var request = MimicPort2Valve.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the PokeInputFilter register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadPokeInputFilterAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PokeInputFilter.Address));
+            return PokeInputFilter.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the PokeInputFilter register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedPokeInputFilterAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(PokeInputFilter.Address));
+            return PokeInputFilter.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the PokeInputFilter register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WritePokeInputFilterAsync(byte value)
+        {
+            var request = PokeInputFilter.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+    }
+}

--- a/Interface/Harp.Behavior/Device.Generated.cs
+++ b/Interface/Harp.Behavior/Device.Generated.cs
@@ -1,0 +1,13754 @@
+using Bonsai;
+using Bonsai.Harp;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+
+namespace Harp.Behavior
+{
+    /// <summary>
+    /// Generates events and processes commands for the Behavior device connected
+    /// at the specified serial port.
+    /// </summary>
+    [Combinator(MethodName = nameof(Generate))]
+    [WorkflowElementCategory(ElementCategory.Source)]
+    [Description("Generates events and processes commands for the Behavior device.")]
+    public partial class Device : Bonsai.Harp.Device, INamedElement
+    {
+        /// <summary>
+        /// Represents the unique identity class of the <see cref="Behavior"/> device.
+        /// This field is constant.
+        /// </summary>
+        public const int WhoAmI = 1216;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Device"/> class.
+        /// </summary>
+        public Device() : base(WhoAmI) { }
+
+        string INamedElement.Name => nameof(Behavior);
+
+        /// <summary>
+        /// Gets a read-only mapping from address to register name.
+        /// </summary>
+        public static new IReadOnlyDictionary<int, string> RegisterMap { get; } = new Dictionary<int, string>
+            (Bonsai.Harp.Device.RegisterMap.ToDictionary(entry => entry.Key, entry => entry.Value))
+        {
+            { 32, "PortDigitalInput" },
+            { 34, "OutputSet" },
+            { 35, "OutputClear" },
+            { 36, "OutputToggle" },
+            { 37, "OutputState" },
+            { 38, "PortDIOSet" },
+            { 39, "PortDIOClear" },
+            { 40, "PortDIOToggle" },
+            { 41, "PortDIOState" },
+            { 42, "PortDIODirection" },
+            { 43, "PortDIOStateEvent" },
+            { 44, "AnalogData" },
+            { 45, "OutputPulseEnable" },
+            { 46, "PulseDOPort0" },
+            { 47, "PulseDOPort1" },
+            { 48, "PulseDOPort2" },
+            { 49, "PulseSupplyPort0" },
+            { 50, "PulseSupplyPort1" },
+            { 51, "PulseSupplyPort2" },
+            { 52, "PulseLed0" },
+            { 53, "PulseLed1" },
+            { 54, "PulseRgb0" },
+            { 55, "PulseRgb1" },
+            { 56, "PulseDO0" },
+            { 57, "PulseDO1" },
+            { 58, "PulseDO2" },
+            { 59, "PulseDO3" },
+            { 60, "PwmFrequencyDO0" },
+            { 61, "PwmFrequencyDO1" },
+            { 62, "PwmFrequencyDO2" },
+            { 63, "PwmFrequencyDO3" },
+            { 64, "PwmDutyCycleDO0" },
+            { 65, "PwmDutyCycleDO1" },
+            { 66, "PwmDutyCycleDO2" },
+            { 67, "PwmDutyCycleDO3" },
+            { 68, "PwmStart" },
+            { 69, "PwmStop" },
+            { 70, "RgbAll" },
+            { 71, "Rgb0" },
+            { 72, "Rgb1" },
+            { 73, "Led0Current" },
+            { 74, "Led1Current" },
+            { 75, "Led0MaxCurrent" },
+            { 76, "Led1MaxCurrent" },
+            { 77, "EventEnable" },
+            { 78, "StartCameras" },
+            { 79, "StopCameras" },
+            { 80, "EnableServos" },
+            { 81, "DisableServos" },
+            { 82, "EnableEncoders" },
+            { 92, "Camera0Frame" },
+            { 93, "Camera0Frequency" },
+            { 94, "Camera1Frame" },
+            { 95, "Camera1Frequency" },
+            { 100, "ServoMotor2Period" },
+            { 101, "ServoMotor2Pulse" },
+            { 102, "ServoMotor3Period" },
+            { 103, "ServoMotor3Pulse" },
+            { 108, "EncoderReset" },
+            { 110, "EnableSerialTimestamp" },
+            { 111, "MimicPort0IR" },
+            { 112, "MimicPort1IR" },
+            { 113, "MimicPort2IR" },
+            { 117, "MimicPort0Valve" },
+            { 118, "MimicPort1Valve" },
+            { 119, "MimicPort2Valve" },
+            { 122, "PokeInputFilter" }
+        };
+    }
+
+    /// <summary>
+    /// Represents an operator that groups the sequence of <see cref="Behavior"/>" messages by register name.
+    /// </summary>
+    [Description("Groups the sequence of Behavior messages by register name.")]
+    public partial class GroupByRegister : Combinator<HarpMessage, IGroupedObservable<string, HarpMessage>>
+    {
+        /// <summary>
+        /// Groups an observable sequence of <see cref="Behavior"/> messages
+        /// by register name.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of observable groups, each of which corresponds to a unique
+        /// <see cref="Behavior"/> register.
+        /// </returns>
+        public override IObservable<IGroupedObservable<string, HarpMessage>> Process(IObservable<HarpMessage> source)
+        {
+            return source.GroupBy(message => Device.RegisterMap[message.Address]);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters register-specific messages
+    /// reported by the <see cref="Behavior"/> device.
+    /// </summary>
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDigitalInput>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputSet>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputClear>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputToggle>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputState>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOSet>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOClear>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOToggle>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOState>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIODirection>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOStateEvent>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<AnalogData>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputPulseEnable>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDOPort0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDOPort1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDOPort2>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseSupplyPort0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseSupplyPort1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseSupplyPort2>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseLed0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseLed1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseRgb0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseRgb1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO2>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO3>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO2>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO3>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO2>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO3>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmStart>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmStop>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<RgbAll>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Rgb0>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Rgb1>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led0Current>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led1Current>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led0MaxCurrent>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led1MaxCurrent>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EventEnable>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<StartCameras>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<StopCameras>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EnableServos>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<DisableServos>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EnableEncoders>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera0Frame>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera0Frequency>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera1Frame>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera1Frequency>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor2Period>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor2Pulse>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor3Period>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor3Pulse>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EncoderReset>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EnableSerialTimestamp>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort0IR>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort1IR>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort2IR>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort0Valve>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort1Valve>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort2Valve>))]
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PokeInputFilter>))]
+    [Description("Filters register-specific messages reported by the Behavior device.")]
+    public class FilterMessage : FilterMessageBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterMessage"/> class.
+        /// </summary>
+        public FilterMessage()
+        {
+            Register = new Bonsai.Expressions.TypeMapping<PortDigitalInput>();
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator which filters and selects specific messages
+    /// reported by the Behavior device.
+    /// </summary>
+    /// <seealso cref="PortDigitalInput"/>
+    /// <seealso cref="OutputSet"/>
+    /// <seealso cref="OutputClear"/>
+    /// <seealso cref="OutputToggle"/>
+    /// <seealso cref="OutputState"/>
+    /// <seealso cref="PortDIOSet"/>
+    /// <seealso cref="PortDIOClear"/>
+    /// <seealso cref="PortDIOToggle"/>
+    /// <seealso cref="PortDIOState"/>
+    /// <seealso cref="PortDIODirection"/>
+    /// <seealso cref="PortDIOStateEvent"/>
+    /// <seealso cref="AnalogData"/>
+    /// <seealso cref="OutputPulseEnable"/>
+    /// <seealso cref="PulseDOPort0"/>
+    /// <seealso cref="PulseDOPort1"/>
+    /// <seealso cref="PulseDOPort2"/>
+    /// <seealso cref="PulseSupplyPort0"/>
+    /// <seealso cref="PulseSupplyPort1"/>
+    /// <seealso cref="PulseSupplyPort2"/>
+    /// <seealso cref="PulseLed0"/>
+    /// <seealso cref="PulseLed1"/>
+    /// <seealso cref="PulseRgb0"/>
+    /// <seealso cref="PulseRgb1"/>
+    /// <seealso cref="PulseDO0"/>
+    /// <seealso cref="PulseDO1"/>
+    /// <seealso cref="PulseDO2"/>
+    /// <seealso cref="PulseDO3"/>
+    /// <seealso cref="PwmFrequencyDO0"/>
+    /// <seealso cref="PwmFrequencyDO1"/>
+    /// <seealso cref="PwmFrequencyDO2"/>
+    /// <seealso cref="PwmFrequencyDO3"/>
+    /// <seealso cref="PwmDutyCycleDO0"/>
+    /// <seealso cref="PwmDutyCycleDO1"/>
+    /// <seealso cref="PwmDutyCycleDO2"/>
+    /// <seealso cref="PwmDutyCycleDO3"/>
+    /// <seealso cref="PwmStart"/>
+    /// <seealso cref="PwmStop"/>
+    /// <seealso cref="RgbAll"/>
+    /// <seealso cref="Rgb0"/>
+    /// <seealso cref="Rgb1"/>
+    /// <seealso cref="Led0Current"/>
+    /// <seealso cref="Led1Current"/>
+    /// <seealso cref="Led0MaxCurrent"/>
+    /// <seealso cref="Led1MaxCurrent"/>
+    /// <seealso cref="EventEnable"/>
+    /// <seealso cref="StartCameras"/>
+    /// <seealso cref="StopCameras"/>
+    /// <seealso cref="EnableServos"/>
+    /// <seealso cref="DisableServos"/>
+    /// <seealso cref="EnableEncoders"/>
+    /// <seealso cref="Camera0Frame"/>
+    /// <seealso cref="Camera0Frequency"/>
+    /// <seealso cref="Camera1Frame"/>
+    /// <seealso cref="Camera1Frequency"/>
+    /// <seealso cref="ServoMotor2Period"/>
+    /// <seealso cref="ServoMotor2Pulse"/>
+    /// <seealso cref="ServoMotor3Period"/>
+    /// <seealso cref="ServoMotor3Pulse"/>
+    /// <seealso cref="EncoderReset"/>
+    /// <seealso cref="EnableSerialTimestamp"/>
+    /// <seealso cref="MimicPort0IR"/>
+    /// <seealso cref="MimicPort1IR"/>
+    /// <seealso cref="MimicPort2IR"/>
+    /// <seealso cref="MimicPort0Valve"/>
+    /// <seealso cref="MimicPort1Valve"/>
+    /// <seealso cref="MimicPort2Valve"/>
+    /// <seealso cref="PokeInputFilter"/>
+    [XmlInclude(typeof(PortDigitalInput))]
+    [XmlInclude(typeof(OutputSet))]
+    [XmlInclude(typeof(OutputClear))]
+    [XmlInclude(typeof(OutputToggle))]
+    [XmlInclude(typeof(OutputState))]
+    [XmlInclude(typeof(PortDIOSet))]
+    [XmlInclude(typeof(PortDIOClear))]
+    [XmlInclude(typeof(PortDIOToggle))]
+    [XmlInclude(typeof(PortDIOState))]
+    [XmlInclude(typeof(PortDIODirection))]
+    [XmlInclude(typeof(PortDIOStateEvent))]
+    [XmlInclude(typeof(AnalogData))]
+    [XmlInclude(typeof(OutputPulseEnable))]
+    [XmlInclude(typeof(PulseDOPort0))]
+    [XmlInclude(typeof(PulseDOPort1))]
+    [XmlInclude(typeof(PulseDOPort2))]
+    [XmlInclude(typeof(PulseSupplyPort0))]
+    [XmlInclude(typeof(PulseSupplyPort1))]
+    [XmlInclude(typeof(PulseSupplyPort2))]
+    [XmlInclude(typeof(PulseLed0))]
+    [XmlInclude(typeof(PulseLed1))]
+    [XmlInclude(typeof(PulseRgb0))]
+    [XmlInclude(typeof(PulseRgb1))]
+    [XmlInclude(typeof(PulseDO0))]
+    [XmlInclude(typeof(PulseDO1))]
+    [XmlInclude(typeof(PulseDO2))]
+    [XmlInclude(typeof(PulseDO3))]
+    [XmlInclude(typeof(PwmFrequencyDO0))]
+    [XmlInclude(typeof(PwmFrequencyDO1))]
+    [XmlInclude(typeof(PwmFrequencyDO2))]
+    [XmlInclude(typeof(PwmFrequencyDO3))]
+    [XmlInclude(typeof(PwmDutyCycleDO0))]
+    [XmlInclude(typeof(PwmDutyCycleDO1))]
+    [XmlInclude(typeof(PwmDutyCycleDO2))]
+    [XmlInclude(typeof(PwmDutyCycleDO3))]
+    [XmlInclude(typeof(PwmStart))]
+    [XmlInclude(typeof(PwmStop))]
+    [XmlInclude(typeof(RgbAll))]
+    [XmlInclude(typeof(Rgb0))]
+    [XmlInclude(typeof(Rgb1))]
+    [XmlInclude(typeof(Led0Current))]
+    [XmlInclude(typeof(Led1Current))]
+    [XmlInclude(typeof(Led0MaxCurrent))]
+    [XmlInclude(typeof(Led1MaxCurrent))]
+    [XmlInclude(typeof(EventEnable))]
+    [XmlInclude(typeof(StartCameras))]
+    [XmlInclude(typeof(StopCameras))]
+    [XmlInclude(typeof(EnableServos))]
+    [XmlInclude(typeof(DisableServos))]
+    [XmlInclude(typeof(EnableEncoders))]
+    [XmlInclude(typeof(Camera0Frame))]
+    [XmlInclude(typeof(Camera0Frequency))]
+    [XmlInclude(typeof(Camera1Frame))]
+    [XmlInclude(typeof(Camera1Frequency))]
+    [XmlInclude(typeof(ServoMotor2Period))]
+    [XmlInclude(typeof(ServoMotor2Pulse))]
+    [XmlInclude(typeof(ServoMotor3Period))]
+    [XmlInclude(typeof(ServoMotor3Pulse))]
+    [XmlInclude(typeof(EncoderReset))]
+    [XmlInclude(typeof(EnableSerialTimestamp))]
+    [XmlInclude(typeof(MimicPort0IR))]
+    [XmlInclude(typeof(MimicPort1IR))]
+    [XmlInclude(typeof(MimicPort2IR))]
+    [XmlInclude(typeof(MimicPort0Valve))]
+    [XmlInclude(typeof(MimicPort1Valve))]
+    [XmlInclude(typeof(MimicPort2Valve))]
+    [XmlInclude(typeof(PokeInputFilter))]
+    [XmlInclude(typeof(TimestampedPortDigitalInput))]
+    [XmlInclude(typeof(TimestampedOutputSet))]
+    [XmlInclude(typeof(TimestampedOutputClear))]
+    [XmlInclude(typeof(TimestampedOutputToggle))]
+    [XmlInclude(typeof(TimestampedOutputState))]
+    [XmlInclude(typeof(TimestampedPortDIOSet))]
+    [XmlInclude(typeof(TimestampedPortDIOClear))]
+    [XmlInclude(typeof(TimestampedPortDIOToggle))]
+    [XmlInclude(typeof(TimestampedPortDIOState))]
+    [XmlInclude(typeof(TimestampedPortDIODirection))]
+    [XmlInclude(typeof(TimestampedPortDIOStateEvent))]
+    [XmlInclude(typeof(TimestampedAnalogData))]
+    [XmlInclude(typeof(TimestampedOutputPulseEnable))]
+    [XmlInclude(typeof(TimestampedPulseDOPort0))]
+    [XmlInclude(typeof(TimestampedPulseDOPort1))]
+    [XmlInclude(typeof(TimestampedPulseDOPort2))]
+    [XmlInclude(typeof(TimestampedPulseSupplyPort0))]
+    [XmlInclude(typeof(TimestampedPulseSupplyPort1))]
+    [XmlInclude(typeof(TimestampedPulseSupplyPort2))]
+    [XmlInclude(typeof(TimestampedPulseLed0))]
+    [XmlInclude(typeof(TimestampedPulseLed1))]
+    [XmlInclude(typeof(TimestampedPulseRgb0))]
+    [XmlInclude(typeof(TimestampedPulseRgb1))]
+    [XmlInclude(typeof(TimestampedPulseDO0))]
+    [XmlInclude(typeof(TimestampedPulseDO1))]
+    [XmlInclude(typeof(TimestampedPulseDO2))]
+    [XmlInclude(typeof(TimestampedPulseDO3))]
+    [XmlInclude(typeof(TimestampedPwmFrequencyDO0))]
+    [XmlInclude(typeof(TimestampedPwmFrequencyDO1))]
+    [XmlInclude(typeof(TimestampedPwmFrequencyDO2))]
+    [XmlInclude(typeof(TimestampedPwmFrequencyDO3))]
+    [XmlInclude(typeof(TimestampedPwmDutyCycleDO0))]
+    [XmlInclude(typeof(TimestampedPwmDutyCycleDO1))]
+    [XmlInclude(typeof(TimestampedPwmDutyCycleDO2))]
+    [XmlInclude(typeof(TimestampedPwmDutyCycleDO3))]
+    [XmlInclude(typeof(TimestampedPwmStart))]
+    [XmlInclude(typeof(TimestampedPwmStop))]
+    [XmlInclude(typeof(TimestampedRgbAll))]
+    [XmlInclude(typeof(TimestampedRgb0))]
+    [XmlInclude(typeof(TimestampedRgb1))]
+    [XmlInclude(typeof(TimestampedLed0Current))]
+    [XmlInclude(typeof(TimestampedLed1Current))]
+    [XmlInclude(typeof(TimestampedLed0MaxCurrent))]
+    [XmlInclude(typeof(TimestampedLed1MaxCurrent))]
+    [XmlInclude(typeof(TimestampedEventEnable))]
+    [XmlInclude(typeof(TimestampedStartCameras))]
+    [XmlInclude(typeof(TimestampedStopCameras))]
+    [XmlInclude(typeof(TimestampedEnableServos))]
+    [XmlInclude(typeof(TimestampedDisableServos))]
+    [XmlInclude(typeof(TimestampedEnableEncoders))]
+    [XmlInclude(typeof(TimestampedCamera0Frame))]
+    [XmlInclude(typeof(TimestampedCamera0Frequency))]
+    [XmlInclude(typeof(TimestampedCamera1Frame))]
+    [XmlInclude(typeof(TimestampedCamera1Frequency))]
+    [XmlInclude(typeof(TimestampedServoMotor2Period))]
+    [XmlInclude(typeof(TimestampedServoMotor2Pulse))]
+    [XmlInclude(typeof(TimestampedServoMotor3Period))]
+    [XmlInclude(typeof(TimestampedServoMotor3Pulse))]
+    [XmlInclude(typeof(TimestampedEncoderReset))]
+    [XmlInclude(typeof(TimestampedEnableSerialTimestamp))]
+    [XmlInclude(typeof(TimestampedMimicPort0IR))]
+    [XmlInclude(typeof(TimestampedMimicPort1IR))]
+    [XmlInclude(typeof(TimestampedMimicPort2IR))]
+    [XmlInclude(typeof(TimestampedMimicPort0Valve))]
+    [XmlInclude(typeof(TimestampedMimicPort1Valve))]
+    [XmlInclude(typeof(TimestampedMimicPort2Valve))]
+    [XmlInclude(typeof(TimestampedPokeInputFilter))]
+    [Description("Filters and selects specific messages reported by the Behavior device.")]
+    public partial class Parse : ParseBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Parse"/> class.
+        /// </summary>
+        public Parse()
+        {
+            Register = new PortDigitalInput();
+        }
+
+        string INamedElement.Name => $"{nameof(Behavior)}.{GetElementDisplayName(Register)}";
+    }
+
+    /// <summary>
+    /// Represents an operator which formats a sequence of values as specific
+    /// Behavior register messages.
+    /// </summary>
+    /// <seealso cref="PortDigitalInput"/>
+    /// <seealso cref="OutputSet"/>
+    /// <seealso cref="OutputClear"/>
+    /// <seealso cref="OutputToggle"/>
+    /// <seealso cref="OutputState"/>
+    /// <seealso cref="PortDIOSet"/>
+    /// <seealso cref="PortDIOClear"/>
+    /// <seealso cref="PortDIOToggle"/>
+    /// <seealso cref="PortDIOState"/>
+    /// <seealso cref="PortDIODirection"/>
+    /// <seealso cref="PortDIOStateEvent"/>
+    /// <seealso cref="AnalogData"/>
+    /// <seealso cref="OutputPulseEnable"/>
+    /// <seealso cref="PulseDOPort0"/>
+    /// <seealso cref="PulseDOPort1"/>
+    /// <seealso cref="PulseDOPort2"/>
+    /// <seealso cref="PulseSupplyPort0"/>
+    /// <seealso cref="PulseSupplyPort1"/>
+    /// <seealso cref="PulseSupplyPort2"/>
+    /// <seealso cref="PulseLed0"/>
+    /// <seealso cref="PulseLed1"/>
+    /// <seealso cref="PulseRgb0"/>
+    /// <seealso cref="PulseRgb1"/>
+    /// <seealso cref="PulseDO0"/>
+    /// <seealso cref="PulseDO1"/>
+    /// <seealso cref="PulseDO2"/>
+    /// <seealso cref="PulseDO3"/>
+    /// <seealso cref="PwmFrequencyDO0"/>
+    /// <seealso cref="PwmFrequencyDO1"/>
+    /// <seealso cref="PwmFrequencyDO2"/>
+    /// <seealso cref="PwmFrequencyDO3"/>
+    /// <seealso cref="PwmDutyCycleDO0"/>
+    /// <seealso cref="PwmDutyCycleDO1"/>
+    /// <seealso cref="PwmDutyCycleDO2"/>
+    /// <seealso cref="PwmDutyCycleDO3"/>
+    /// <seealso cref="PwmStart"/>
+    /// <seealso cref="PwmStop"/>
+    /// <seealso cref="RgbAll"/>
+    /// <seealso cref="Rgb0"/>
+    /// <seealso cref="Rgb1"/>
+    /// <seealso cref="Led0Current"/>
+    /// <seealso cref="Led1Current"/>
+    /// <seealso cref="Led0MaxCurrent"/>
+    /// <seealso cref="Led1MaxCurrent"/>
+    /// <seealso cref="EventEnable"/>
+    /// <seealso cref="StartCameras"/>
+    /// <seealso cref="StopCameras"/>
+    /// <seealso cref="EnableServos"/>
+    /// <seealso cref="DisableServos"/>
+    /// <seealso cref="EnableEncoders"/>
+    /// <seealso cref="Camera0Frame"/>
+    /// <seealso cref="Camera0Frequency"/>
+    /// <seealso cref="Camera1Frame"/>
+    /// <seealso cref="Camera1Frequency"/>
+    /// <seealso cref="ServoMotor2Period"/>
+    /// <seealso cref="ServoMotor2Pulse"/>
+    /// <seealso cref="ServoMotor3Period"/>
+    /// <seealso cref="ServoMotor3Pulse"/>
+    /// <seealso cref="EncoderReset"/>
+    /// <seealso cref="EnableSerialTimestamp"/>
+    /// <seealso cref="MimicPort0IR"/>
+    /// <seealso cref="MimicPort1IR"/>
+    /// <seealso cref="MimicPort2IR"/>
+    /// <seealso cref="MimicPort0Valve"/>
+    /// <seealso cref="MimicPort1Valve"/>
+    /// <seealso cref="MimicPort2Valve"/>
+    /// <seealso cref="PokeInputFilter"/>
+    [XmlInclude(typeof(PortDigitalInput))]
+    [XmlInclude(typeof(OutputSet))]
+    [XmlInclude(typeof(OutputClear))]
+    [XmlInclude(typeof(OutputToggle))]
+    [XmlInclude(typeof(OutputState))]
+    [XmlInclude(typeof(PortDIOSet))]
+    [XmlInclude(typeof(PortDIOClear))]
+    [XmlInclude(typeof(PortDIOToggle))]
+    [XmlInclude(typeof(PortDIOState))]
+    [XmlInclude(typeof(PortDIODirection))]
+    [XmlInclude(typeof(PortDIOStateEvent))]
+    [XmlInclude(typeof(AnalogData))]
+    [XmlInclude(typeof(OutputPulseEnable))]
+    [XmlInclude(typeof(PulseDOPort0))]
+    [XmlInclude(typeof(PulseDOPort1))]
+    [XmlInclude(typeof(PulseDOPort2))]
+    [XmlInclude(typeof(PulseSupplyPort0))]
+    [XmlInclude(typeof(PulseSupplyPort1))]
+    [XmlInclude(typeof(PulseSupplyPort2))]
+    [XmlInclude(typeof(PulseLed0))]
+    [XmlInclude(typeof(PulseLed1))]
+    [XmlInclude(typeof(PulseRgb0))]
+    [XmlInclude(typeof(PulseRgb1))]
+    [XmlInclude(typeof(PulseDO0))]
+    [XmlInclude(typeof(PulseDO1))]
+    [XmlInclude(typeof(PulseDO2))]
+    [XmlInclude(typeof(PulseDO3))]
+    [XmlInclude(typeof(PwmFrequencyDO0))]
+    [XmlInclude(typeof(PwmFrequencyDO1))]
+    [XmlInclude(typeof(PwmFrequencyDO2))]
+    [XmlInclude(typeof(PwmFrequencyDO3))]
+    [XmlInclude(typeof(PwmDutyCycleDO0))]
+    [XmlInclude(typeof(PwmDutyCycleDO1))]
+    [XmlInclude(typeof(PwmDutyCycleDO2))]
+    [XmlInclude(typeof(PwmDutyCycleDO3))]
+    [XmlInclude(typeof(PwmStart))]
+    [XmlInclude(typeof(PwmStop))]
+    [XmlInclude(typeof(RgbAll))]
+    [XmlInclude(typeof(Rgb0))]
+    [XmlInclude(typeof(Rgb1))]
+    [XmlInclude(typeof(Led0Current))]
+    [XmlInclude(typeof(Led1Current))]
+    [XmlInclude(typeof(Led0MaxCurrent))]
+    [XmlInclude(typeof(Led1MaxCurrent))]
+    [XmlInclude(typeof(EventEnable))]
+    [XmlInclude(typeof(StartCameras))]
+    [XmlInclude(typeof(StopCameras))]
+    [XmlInclude(typeof(EnableServos))]
+    [XmlInclude(typeof(DisableServos))]
+    [XmlInclude(typeof(EnableEncoders))]
+    [XmlInclude(typeof(Camera0Frame))]
+    [XmlInclude(typeof(Camera0Frequency))]
+    [XmlInclude(typeof(Camera1Frame))]
+    [XmlInclude(typeof(Camera1Frequency))]
+    [XmlInclude(typeof(ServoMotor2Period))]
+    [XmlInclude(typeof(ServoMotor2Pulse))]
+    [XmlInclude(typeof(ServoMotor3Period))]
+    [XmlInclude(typeof(ServoMotor3Pulse))]
+    [XmlInclude(typeof(EncoderReset))]
+    [XmlInclude(typeof(EnableSerialTimestamp))]
+    [XmlInclude(typeof(MimicPort0IR))]
+    [XmlInclude(typeof(MimicPort1IR))]
+    [XmlInclude(typeof(MimicPort2IR))]
+    [XmlInclude(typeof(MimicPort0Valve))]
+    [XmlInclude(typeof(MimicPort1Valve))]
+    [XmlInclude(typeof(MimicPort2Valve))]
+    [XmlInclude(typeof(PokeInputFilter))]
+    [Description("Formats a sequence of values as specific Behavior register messages.")]
+    public partial class Format : FormatBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Format"/> class.
+        /// </summary>
+        public Format()
+        {
+            Register = new PortDigitalInput();
+        }
+
+        string INamedElement.Name => $"{nameof(Behavior)}.{GetElementDisplayName(Register)}";
+    }
+
+    /// <summary>
+    /// Represents an operator that reflects the state of DI digital lines of each Port.
+    /// </summary>
+    [Description("Reflects the state of DI digital lines of each Port")]
+    public partial class PortDigitalInput : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDigitalInput"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 32;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDigitalInput"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDigitalInput"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortDigitalInput"/> class.
+        /// </summary>
+        public PortDigitalInput()
+        {
+            MessageType = MessageType.Event;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDigitalInput"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static DigitalInputs GetPayload(HarpMessage message)
+        {
+            return (DigitalInputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDigitalInput"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalInputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((DigitalInputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDigitalInput"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDigitalInput"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, DigitalInputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDigitalInput"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDigitalInput"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, DigitalInputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDigitalInput"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="DigitalInputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<DigitalInputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDigitalInput"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="DigitalInputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDigitalInput"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<DigitalInputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDigitalInput"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="DigitalInputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDigitalInput"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalInputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDigitalInput register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDigitalInput register.")]
+    public partial class TimestampedPortDigitalInput : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDigitalInput"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="DigitalInputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<DigitalInputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDigitalInput.Address, MessageType).Select(PortDigitalInput.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that set the specified digital output lines.
+    /// </summary>
+    [Description("Set the specified digital output lines.")]
+    public partial class OutputSet : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="OutputSet"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 34;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="OutputSet"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="OutputSet"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="OutputSet"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static DigitalOutputs GetPayload(HarpMessage message)
+        {
+            return (DigitalOutputs)message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="OutputSet"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadUInt16();
+            return Timestamped.Create((DigitalOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="OutputSet"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputSet"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="OutputSet"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputSet"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="OutputSet"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="OutputSet"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="OutputSet"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="OutputSet"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="OutputSet"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the OutputSet register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the OutputSet register.")]
+    public partial class TimestampedOutputSet : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="OutputSet"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(OutputSet.Address, MessageType).Select(OutputSet.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that clear the specified digital output lines.
+    /// </summary>
+    [Description("Clear the specified digital output lines")]
+    public partial class OutputClear : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="OutputClear"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 35;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="OutputClear"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="OutputClear"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="OutputClear"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static DigitalOutputs GetPayload(HarpMessage message)
+        {
+            return (DigitalOutputs)message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="OutputClear"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadUInt16();
+            return Timestamped.Create((DigitalOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="OutputClear"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputClear"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="OutputClear"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputClear"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="OutputClear"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="OutputClear"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="OutputClear"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="OutputClear"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="OutputClear"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the OutputClear register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the OutputClear register.")]
+    public partial class TimestampedOutputClear : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="OutputClear"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(OutputClear.Address, MessageType).Select(OutputClear.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that toggle the specified digital output lines.
+    /// </summary>
+    [Description("Toggle the specified digital output lines")]
+    public partial class OutputToggle : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="OutputToggle"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 36;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="OutputToggle"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="OutputToggle"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="OutputToggle"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static DigitalOutputs GetPayload(HarpMessage message)
+        {
+            return (DigitalOutputs)message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="OutputToggle"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadUInt16();
+            return Timestamped.Create((DigitalOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="OutputToggle"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputToggle"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="OutputToggle"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputToggle"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="OutputToggle"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="OutputToggle"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="OutputToggle"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="OutputToggle"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="OutputToggle"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the OutputToggle register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the OutputToggle register.")]
+    public partial class TimestampedOutputToggle : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="OutputToggle"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(OutputToggle.Address, MessageType).Select(OutputToggle.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that write the state of all digital output lines.
+    /// </summary>
+    [Description("Write the state of all digital output lines")]
+    public partial class OutputState : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="OutputState"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 37;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="OutputState"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="OutputState"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="OutputState"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static DigitalOutputs GetPayload(HarpMessage message)
+        {
+            return (DigitalOutputs)message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="OutputState"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadUInt16();
+            return Timestamped.Create((DigitalOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="OutputState"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputState"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="OutputState"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputState"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="OutputState"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="OutputState"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="OutputState"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="OutputState"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="OutputState"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the OutputState register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the OutputState register.")]
+    public partial class TimestampedOutputState : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="OutputState"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(OutputState.Address, MessageType).Select(OutputState.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that set the specified port DIO lines.
+    /// </summary>
+    [Description("Set the specified port DIO lines")]
+    public partial class PortDIOSet : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDIOSet"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 38;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDIOSet"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDIOSet"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDIOSet"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PortDigitalIOS GetPayload(HarpMessage message)
+        {
+            return (PortDigitalIOS)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDIOSet"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PortDigitalIOS)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDIOSet"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOSet"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDIOSet"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOSet"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDIOSet"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDIOSet"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDIOSet"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDIOSet"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDIOSet"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDIOSet register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDIOSet register.")]
+    public partial class TimestampedPortDIOSet : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDIOSet"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDIOSet.Address, MessageType).Select(PortDIOSet.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that clear the specified port DIO lines.
+    /// </summary>
+    [Description("Clear the specified port DIO lines")]
+    public partial class PortDIOClear : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDIOClear"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 39;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDIOClear"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDIOClear"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDIOClear"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PortDigitalIOS GetPayload(HarpMessage message)
+        {
+            return (PortDigitalIOS)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDIOClear"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PortDigitalIOS)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDIOClear"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOClear"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDIOClear"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOClear"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDIOClear"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDIOClear"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDIOClear"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDIOClear"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDIOClear"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDIOClear register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDIOClear register.")]
+    public partial class TimestampedPortDIOClear : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDIOClear"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDIOClear.Address, MessageType).Select(PortDIOClear.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that toggle the specified port DIO lines.
+    /// </summary>
+    [Description("Toggle the specified port DIO lines")]
+    public partial class PortDIOToggle : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDIOToggle"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 40;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDIOToggle"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDIOToggle"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDIOToggle"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PortDigitalIOS GetPayload(HarpMessage message)
+        {
+            return (PortDigitalIOS)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDIOToggle"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PortDigitalIOS)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDIOToggle"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOToggle"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDIOToggle"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOToggle"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDIOToggle"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDIOToggle"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDIOToggle"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDIOToggle"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDIOToggle"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDIOToggle register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDIOToggle register.")]
+    public partial class TimestampedPortDIOToggle : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDIOToggle"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDIOToggle.Address, MessageType).Select(PortDIOToggle.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that write the state of all port DIO lines.
+    /// </summary>
+    [Description("Write the state of all port DIO lines")]
+    public partial class PortDIOState : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDIOState"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 41;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDIOState"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDIOState"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDIOState"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PortDigitalIOS GetPayload(HarpMessage message)
+        {
+            return (PortDigitalIOS)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDIOState"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PortDigitalIOS)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDIOState"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOState"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDIOState"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOState"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDIOState"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDIOState"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDIOState"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDIOState"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDIOState"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDIOState register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDIOState register.")]
+    public partial class TimestampedPortDIOState : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDIOState"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDIOState.Address, MessageType).Select(PortDIOState.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies which of the port DIO lines are outputs.
+    /// </summary>
+    [Description("Specifies which of the port DIO lines are outputs")]
+    public partial class PortDIODirection : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDIODirection"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 42;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDIODirection"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDIODirection"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDIODirection"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PortDigitalIOS GetPayload(HarpMessage message)
+        {
+            return (PortDigitalIOS)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDIODirection"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PortDigitalIOS)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDIODirection"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIODirection"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDIODirection"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIODirection"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDIODirection"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDIODirection"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDIODirection"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDIODirection"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDIODirection"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDIODirection register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDIODirection register.")]
+    public partial class TimestampedPortDIODirection : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDIODirection"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDIODirection.Address, MessageType).Select(PortDIODirection.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the state of the port DIO lines on a line change.
+    /// </summary>
+    [Description("Specifies the state of the port DIO lines on a line change")]
+    public partial class PortDIOStateEvent : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PortDIOStateEvent"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 43;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PortDIOStateEvent"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PortDIOStateEvent"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortDIOStateEvent"/> class.
+        /// </summary>
+        public PortDIOStateEvent()
+        {
+            MessageType = MessageType.Event;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PortDIOStateEvent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PortDigitalIOS GetPayload(HarpMessage message)
+        {
+            return (PortDigitalIOS)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PortDIOStateEvent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PortDigitalIOS)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PortDIOStateEvent"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOStateEvent"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PortDIOStateEvent"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PortDIOStateEvent"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PortDigitalIOS value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PortDIOStateEvent"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PortDIOStateEvent"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PortDIOStateEvent"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PortDIOStateEvent"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PortDIOStateEvent"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PortDIOStateEvent register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PortDIOStateEvent register.")]
+    public partial class TimestampedPortDIOStateEvent : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PortDIOStateEvent"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PortDIOStateEvent.Address, MessageType).Select(PortDIOStateEvent.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that voltage at the ADC input and encoder value on Port 2.
+    /// </summary>
+    [Description("Voltage at the ADC input and encoder value on Port 2")]
+    public partial class AnalogData : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="AnalogData"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 44;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="AnalogData"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.S16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="AnalogData"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 2;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnalogData"/> class.
+        /// </summary>
+        public AnalogData()
+        {
+            MessageType = MessageType.Event;
+        }
+
+        static AnalogDataPayload ParsePayload(short[] payload)
+        {
+            AnalogDataPayload result;
+            result.AnalogInput = payload[0];
+            result.Encoder = payload[1];
+            return result;
+        }
+
+        static short[] FormatPayload(AnalogDataPayload value)
+        {
+            short[] result;
+            result = new short[2];
+            result[0] = value.AnalogInput;
+            result[1] = value.Encoder;
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="AnalogData"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static AnalogDataPayload GetPayload(HarpMessage message)
+        {
+            return ParsePayload(message.GetPayloadArray<short>());
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="AnalogData"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<AnalogDataPayload> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadArray<short>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="AnalogData"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="AnalogData"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, AnalogDataPayload value)
+        {
+            return HarpMessage.FromInt16(Address, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="AnalogData"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="AnalogData"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, AnalogDataPayload value)
+        {
+            return HarpMessage.FromInt16(Address, timestamp, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="AnalogData"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="AnalogDataPayload"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<AnalogDataPayload> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="AnalogData"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="AnalogDataPayload"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="AnalogData"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<AnalogDataPayload> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="AnalogData"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="AnalogDataPayload"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="AnalogData"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<AnalogDataPayload>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the AnalogData register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the AnalogData register.")]
+    public partial class TimestampedAnalogData : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="AnalogData"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="AnalogDataPayload"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<AnalogDataPayload>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(AnalogData.Address, MessageType).Select(AnalogData.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that enables the pulse function for the specified output lines.
+    /// </summary>
+    [Description("Enables the pulse function for the specified output lines")]
+    public partial class OutputPulseEnable : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="OutputPulseEnable"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 45;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="OutputPulseEnable"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="OutputPulseEnable"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="OutputPulseEnable"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static DigitalOutputs GetPayload(HarpMessage message)
+        {
+            return (DigitalOutputs)message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="OutputPulseEnable"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadUInt16();
+            return Timestamped.Create((DigitalOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="OutputPulseEnable"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputPulseEnable"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="OutputPulseEnable"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="OutputPulseEnable"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, DigitalOutputs value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="OutputPulseEnable"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="OutputPulseEnable"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="OutputPulseEnable"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="OutputPulseEnable"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="OutputPulseEnable"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the OutputPulseEnable register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the OutputPulseEnable register.")]
+    public partial class TimestampedOutputPulseEnable : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="OutputPulseEnable"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(OutputPulseEnable.Address, MessageType).Select(OutputPulseEnable.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDOPort0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDOPort0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 46;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDOPort0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDOPort0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDOPort0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDOPort0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDOPort0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDOPort0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDOPort0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDOPort0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDOPort0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDOPort0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDOPort0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDOPort0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDOPort0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDOPort0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDOPort0 register.")]
+    public partial class TimestampedPulseDOPort0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDOPort0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDOPort0.Address, MessageType).Select(PulseDOPort0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDOPort1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDOPort1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 47;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDOPort1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDOPort1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDOPort1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDOPort1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDOPort1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDOPort1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDOPort1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDOPort1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDOPort1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDOPort1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDOPort1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDOPort1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDOPort1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDOPort1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDOPort1 register.")]
+    public partial class TimestampedPulseDOPort1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDOPort1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDOPort1.Address, MessageType).Select(PulseDOPort1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDOPort2 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDOPort2"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 48;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDOPort2"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDOPort2"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDOPort2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDOPort2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDOPort2"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDOPort2"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDOPort2"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDOPort2"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDOPort2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDOPort2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDOPort2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDOPort2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDOPort2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDOPort2 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDOPort2 register.")]
+    public partial class TimestampedPulseDOPort2 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDOPort2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDOPort2.Address, MessageType).Select(PulseDOPort2.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseSupplyPort0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseSupplyPort0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 49;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseSupplyPort0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseSupplyPort0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseSupplyPort0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseSupplyPort0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseSupplyPort0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseSupplyPort0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseSupplyPort0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseSupplyPort0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseSupplyPort0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseSupplyPort0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseSupplyPort0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseSupplyPort0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseSupplyPort0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseSupplyPort0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseSupplyPort0 register.")]
+    public partial class TimestampedPulseSupplyPort0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseSupplyPort0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseSupplyPort0.Address, MessageType).Select(PulseSupplyPort0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseSupplyPort1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseSupplyPort1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 50;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseSupplyPort1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseSupplyPort1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseSupplyPort1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseSupplyPort1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseSupplyPort1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseSupplyPort1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseSupplyPort1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseSupplyPort1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseSupplyPort1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseSupplyPort1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseSupplyPort1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseSupplyPort1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseSupplyPort1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseSupplyPort1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseSupplyPort1 register.")]
+    public partial class TimestampedPulseSupplyPort1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseSupplyPort1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseSupplyPort1.Address, MessageType).Select(PulseSupplyPort1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseSupplyPort2 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseSupplyPort2"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 51;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseSupplyPort2"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseSupplyPort2"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseSupplyPort2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseSupplyPort2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseSupplyPort2"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseSupplyPort2"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseSupplyPort2"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseSupplyPort2"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseSupplyPort2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseSupplyPort2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseSupplyPort2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseSupplyPort2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseSupplyPort2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseSupplyPort2 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseSupplyPort2 register.")]
+    public partial class TimestampedPulseSupplyPort2 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseSupplyPort2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseSupplyPort2.Address, MessageType).Select(PulseSupplyPort2.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseLed0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseLed0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 52;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseLed0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseLed0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseLed0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseLed0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseLed0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseLed0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseLed0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseLed0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseLed0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseLed0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseLed0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseLed0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseLed0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseLed0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseLed0 register.")]
+    public partial class TimestampedPulseLed0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseLed0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseLed0.Address, MessageType).Select(PulseLed0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseLed1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseLed1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 53;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseLed1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseLed1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseLed1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseLed1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseLed1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseLed1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseLed1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseLed1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseLed1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseLed1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseLed1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseLed1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseLed1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseLed1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseLed1 register.")]
+    public partial class TimestampedPulseLed1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseLed1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseLed1.Address, MessageType).Select(PulseLed1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseRgb0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseRgb0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 54;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseRgb0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseRgb0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseRgb0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseRgb0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseRgb0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseRgb0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseRgb0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseRgb0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseRgb0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseRgb0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseRgb0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseRgb0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseRgb0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseRgb0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseRgb0 register.")]
+    public partial class TimestampedPulseRgb0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseRgb0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseRgb0.Address, MessageType).Select(PulseRgb0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseRgb1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseRgb1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 55;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseRgb1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseRgb1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseRgb1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseRgb1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseRgb1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseRgb1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseRgb1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseRgb1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseRgb1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseRgb1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseRgb1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseRgb1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseRgb1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseRgb1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseRgb1 register.")]
+    public partial class TimestampedPulseRgb1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseRgb1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseRgb1.Address, MessageType).Select(PulseRgb1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDO0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDO0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 56;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDO0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDO0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDO0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDO0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDO0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDO0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDO0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDO0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDO0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDO0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDO0 register.")]
+    public partial class TimestampedPulseDO0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDO0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDO0.Address, MessageType).Select(PulseDO0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDO1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDO1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 57;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDO1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDO1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDO1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDO1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDO1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDO1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDO1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDO1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDO1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDO1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDO1 register.")]
+    public partial class TimestampedPulseDO1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDO1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDO1.Address, MessageType).Select(PulseDO1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDO2 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDO2"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 58;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDO2"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDO2"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDO2"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO2"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDO2"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO2"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDO2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDO2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDO2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDO2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDO2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDO2 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDO2 register.")]
+    public partial class TimestampedPulseDO2 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDO2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDO2.Address, MessageType).Select(PulseDO2.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [Description("Specifies the duration of the output pulse in milliseconds.")]
+    public partial class PulseDO3 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PulseDO3"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 59;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PulseDO3"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PulseDO3"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PulseDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PulseDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PulseDO3"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO3"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PulseDO3"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PulseDO3"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PulseDO3"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PulseDO3"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PulseDO3"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PulseDO3"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PulseDO3"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PulseDO3 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PulseDO3 register.")]
+    public partial class TimestampedPulseDO3 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PulseDO3"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PulseDO3.Address, MessageType).Select(PulseDO3.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the frequency of the PWM at DO0.
+    /// </summary>
+    [Description("Specifies the frequency of the PWM at DO0.")]
+    public partial class PwmFrequencyDO0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmFrequencyDO0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 60;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmFrequencyDO0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmFrequencyDO0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmFrequencyDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmFrequencyDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmFrequencyDO0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmFrequencyDO0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmFrequencyDO0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmFrequencyDO0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmFrequencyDO0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmFrequencyDO0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmFrequencyDO0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmFrequencyDO0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmFrequencyDO0 register.")]
+    public partial class TimestampedPwmFrequencyDO0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmFrequencyDO0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmFrequencyDO0.Address, MessageType).Select(PwmFrequencyDO0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the frequency of the PWM at DO1.
+    /// </summary>
+    [Description("Specifies the frequency of the PWM at DO1.")]
+    public partial class PwmFrequencyDO1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmFrequencyDO1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 61;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmFrequencyDO1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmFrequencyDO1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmFrequencyDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmFrequencyDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmFrequencyDO1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmFrequencyDO1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmFrequencyDO1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmFrequencyDO1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmFrequencyDO1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmFrequencyDO1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmFrequencyDO1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmFrequencyDO1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmFrequencyDO1 register.")]
+    public partial class TimestampedPwmFrequencyDO1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmFrequencyDO1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmFrequencyDO1.Address, MessageType).Select(PwmFrequencyDO1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the frequency of the PWM at DO2.
+    /// </summary>
+    [Description("Specifies the frequency of the PWM at DO2.")]
+    public partial class PwmFrequencyDO2 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmFrequencyDO2"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 62;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmFrequencyDO2"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmFrequencyDO2"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmFrequencyDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmFrequencyDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmFrequencyDO2"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO2"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmFrequencyDO2"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO2"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmFrequencyDO2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmFrequencyDO2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmFrequencyDO2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmFrequencyDO2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmFrequencyDO2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmFrequencyDO2 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmFrequencyDO2 register.")]
+    public partial class TimestampedPwmFrequencyDO2 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmFrequencyDO2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmFrequencyDO2.Address, MessageType).Select(PwmFrequencyDO2.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the frequency of the PWM at DO3.
+    /// </summary>
+    [Description("Specifies the frequency of the PWM at DO3.")]
+    public partial class PwmFrequencyDO3 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmFrequencyDO3"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 63;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmFrequencyDO3"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmFrequencyDO3"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmFrequencyDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmFrequencyDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmFrequencyDO3"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO3"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmFrequencyDO3"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmFrequencyDO3"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmFrequencyDO3"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmFrequencyDO3"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmFrequencyDO3"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmFrequencyDO3"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmFrequencyDO3"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmFrequencyDO3 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmFrequencyDO3 register.")]
+    public partial class TimestampedPwmFrequencyDO3 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmFrequencyDO3"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmFrequencyDO3.Address, MessageType).Select(PwmFrequencyDO3.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duty cycle of the PWM at DO0.
+    /// </summary>
+    [Description("Specifies the duty cycle of the PWM at DO0.")]
+    public partial class PwmDutyCycleDO0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmDutyCycleDO0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 64;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmDutyCycleDO0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmDutyCycleDO0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmDutyCycleDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmDutyCycleDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmDutyCycleDO0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmDutyCycleDO0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmDutyCycleDO0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmDutyCycleDO0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmDutyCycleDO0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmDutyCycleDO0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmDutyCycleDO0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmDutyCycleDO0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmDutyCycleDO0 register.")]
+    public partial class TimestampedPwmDutyCycleDO0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmDutyCycleDO0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmDutyCycleDO0.Address, MessageType).Select(PwmDutyCycleDO0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duty cycle of the PWM at DO1.
+    /// </summary>
+    [Description("Specifies the duty cycle of the PWM at DO1.")]
+    public partial class PwmDutyCycleDO1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmDutyCycleDO1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 65;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmDutyCycleDO1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmDutyCycleDO1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmDutyCycleDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmDutyCycleDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmDutyCycleDO1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmDutyCycleDO1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmDutyCycleDO1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmDutyCycleDO1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmDutyCycleDO1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmDutyCycleDO1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmDutyCycleDO1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmDutyCycleDO1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmDutyCycleDO1 register.")]
+    public partial class TimestampedPwmDutyCycleDO1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmDutyCycleDO1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmDutyCycleDO1.Address, MessageType).Select(PwmDutyCycleDO1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duty cycle of the PWM at DO2.
+    /// </summary>
+    [Description("Specifies the duty cycle of the PWM at DO2.")]
+    public partial class PwmDutyCycleDO2 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmDutyCycleDO2"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 66;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmDutyCycleDO2"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmDutyCycleDO2"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmDutyCycleDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmDutyCycleDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmDutyCycleDO2"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO2"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmDutyCycleDO2"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO2"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmDutyCycleDO2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmDutyCycleDO2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmDutyCycleDO2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmDutyCycleDO2"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmDutyCycleDO2"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmDutyCycleDO2 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmDutyCycleDO2 register.")]
+    public partial class TimestampedPwmDutyCycleDO2 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmDutyCycleDO2"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmDutyCycleDO2.Address, MessageType).Select(PwmDutyCycleDO2.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the duty cycle of the PWM at DO3.
+    /// </summary>
+    [Description("Specifies the duty cycle of the PWM at DO3.")]
+    public partial class PwmDutyCycleDO3 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmDutyCycleDO3"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 67;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmDutyCycleDO3"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmDutyCycleDO3"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmDutyCycleDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmDutyCycleDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmDutyCycleDO3"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO3"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmDutyCycleDO3"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmDutyCycleDO3"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmDutyCycleDO3"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmDutyCycleDO3"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmDutyCycleDO3"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmDutyCycleDO3"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmDutyCycleDO3"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmDutyCycleDO3 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmDutyCycleDO3 register.")]
+    public partial class TimestampedPwmDutyCycleDO3 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmDutyCycleDO3"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmDutyCycleDO3.Address, MessageType).Select(PwmDutyCycleDO3.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that starts the PWM on the selected output lines.
+    /// </summary>
+    [Description("Starts the PWM on the selected output lines.")]
+    public partial class PwmStart : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmStart"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 68;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmStart"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmStart"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmStart"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static PwmOutputs GetPayload(HarpMessage message)
+        {
+            return (PwmOutputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmStart"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PwmOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((PwmOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmStart"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmStart"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, PwmOutputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmStart"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmStart"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, PwmOutputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmStart"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="PwmOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<PwmOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmStart"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="PwmOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmStart"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<PwmOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmStart"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="PwmOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmStart"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PwmOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmStart register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmStart register.")]
+    public partial class TimestampedPwmStart : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmStart"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="PwmOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<PwmOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmStart.Address, MessageType).Select(PwmStart.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that stops the PWM on the selected output lines.
+    /// </summary>
+    [Description("Stops the PWM on the selected output lines.")]
+    public partial class PwmStop : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PwmStop"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 69;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PwmStop"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PwmStop"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PwmStop"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PwmStop"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PwmStop"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmStop"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PwmStop"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PwmStop"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PwmStop"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PwmStop"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PwmStop"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PwmStop"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PwmStop"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PwmStop register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PwmStop register.")]
+    public partial class TimestampedPwmStop : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PwmStop"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PwmStop.Address, MessageType).Select(PwmStop.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the state of all RGB LED channels.
+    /// </summary>
+    [Description("Specifies the state of all RGB LED channels.")]
+    public partial class RgbAll : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="RgbAll"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 70;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="RgbAll"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="RgbAll"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 6;
+
+        static RgbAllPayload ParsePayload(byte[] payload)
+        {
+            RgbAllPayload result;
+            result.Green0 = payload[0];
+            result.Red0 = payload[1];
+            result.Blue0 = payload[2];
+            result.Green1 = payload[3];
+            result.Red1 = payload[4];
+            result.Blue1 = payload[5];
+            return result;
+        }
+
+        static byte[] FormatPayload(RgbAllPayload value)
+        {
+            byte[] result;
+            result = new byte[6];
+            result[0] = value.Green0;
+            result[1] = value.Red0;
+            result[2] = value.Blue0;
+            result[3] = value.Green1;
+            result[4] = value.Red1;
+            result[5] = value.Blue1;
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="RgbAll"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static RgbAllPayload GetPayload(HarpMessage message)
+        {
+            return ParsePayload(message.GetPayloadArray<byte>());
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="RgbAll"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<RgbAllPayload> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadArray<byte>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="RgbAll"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="RgbAll"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, RgbAllPayload value)
+        {
+            return HarpMessage.FromByte(Address, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="RgbAll"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="RgbAll"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, RgbAllPayload value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="RgbAll"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="RgbAllPayload"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<RgbAllPayload> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="RgbAll"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="RgbAllPayload"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="RgbAll"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<RgbAllPayload> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="RgbAll"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="RgbAllPayload"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="RgbAll"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<RgbAllPayload>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the RgbAll register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the RgbAll register.")]
+    public partial class TimestampedRgbAll : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="RgbAll"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="RgbAllPayload"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<RgbAllPayload>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(RgbAll.Address, MessageType).Select(RgbAll.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the state of the RGB0 LED channels.
+    /// </summary>
+    [Description("Specifies the state of the RGB0 LED channels.")]
+    public partial class Rgb0 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Rgb0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 71;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Rgb0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Rgb0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 3;
+
+        static RgbPayload ParsePayload(byte[] payload)
+        {
+            RgbPayload result;
+            result.Green = payload[0];
+            result.Red = payload[1];
+            result.Blue = payload[2];
+            return result;
+        }
+
+        static byte[] FormatPayload(RgbPayload value)
+        {
+            byte[] result;
+            result = new byte[3];
+            result[0] = value.Green;
+            result[1] = value.Red;
+            result[2] = value.Blue;
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Rgb0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static RgbPayload GetPayload(HarpMessage message)
+        {
+            return ParsePayload(message.GetPayloadArray<byte>());
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Rgb0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<RgbPayload> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadArray<byte>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Rgb0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Rgb0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, RgbPayload value)
+        {
+            return HarpMessage.FromByte(Address, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Rgb0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Rgb0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, RgbPayload value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Rgb0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="RgbPayload"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<RgbPayload> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Rgb0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="RgbPayload"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Rgb0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<RgbPayload> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Rgb0"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="RgbPayload"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Rgb0"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<RgbPayload>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Rgb0 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Rgb0 register.")]
+    public partial class TimestampedRgb0 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Rgb0"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="RgbPayload"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<RgbPayload>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Rgb0.Address, MessageType).Select(Rgb0.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the state of the RGB1 LED channels.
+    /// </summary>
+    [Description("Specifies the state of the RGB1 LED channels.")]
+    public partial class Rgb1 : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Rgb1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 72;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Rgb1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Rgb1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 3;
+
+        static RgbPayload ParsePayload(byte[] payload)
+        {
+            RgbPayload result;
+            result.Green = payload[0];
+            result.Red = payload[1];
+            result.Blue = payload[2];
+            return result;
+        }
+
+        static byte[] FormatPayload(RgbPayload value)
+        {
+            byte[] result;
+            result = new byte[3];
+            result[0] = value.Green;
+            result[1] = value.Red;
+            result[2] = value.Blue;
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Rgb1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static RgbPayload GetPayload(HarpMessage message)
+        {
+            return ParsePayload(message.GetPayloadArray<byte>());
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Rgb1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<RgbPayload> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadArray<byte>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Rgb1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Rgb1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, RgbPayload value)
+        {
+            return HarpMessage.FromByte(Address, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Rgb1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Rgb1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, RgbPayload value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Rgb1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="RgbPayload"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<RgbPayload> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Rgb1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="RgbPayload"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Rgb1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<RgbPayload> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Rgb1"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="RgbPayload"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Rgb1"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<RgbPayload>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Rgb1 register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Rgb1 register.")]
+    public partial class TimestampedRgb1 : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Rgb1"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="RgbPayload"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<RgbPayload>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Rgb1.Address, MessageType).Select(Rgb1.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the configuration of current to drive LED 0.
+    /// </summary>
+    [Description("Specifies the configuration of current to drive LED 0.")]
+    public partial class Led0Current : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Led0Current"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 73;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Led0Current"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Led0Current"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Led0Current"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Led0Current"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Led0Current"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led0Current"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Led0Current"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led0Current"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Led0Current"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Led0Current"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Led0Current"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Led0Current"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Led0Current"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Led0Current register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Led0Current register.")]
+    public partial class TimestampedLed0Current : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Led0Current"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Led0Current.Address, MessageType).Select(Led0Current.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the configuration of current to drive LED 1.
+    /// </summary>
+    [Description("Specifies the configuration of current to drive LED 1.")]
+    public partial class Led1Current : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Led1Current"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 74;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Led1Current"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Led1Current"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Led1Current"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Led1Current"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Led1Current"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led1Current"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Led1Current"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led1Current"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Led1Current"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Led1Current"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Led1Current"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Led1Current"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Led1Current"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Led1Current register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Led1Current register.")]
+    public partial class TimestampedLed1Current : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Led1Current"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Led1Current.Address, MessageType).Select(Led1Current.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the configuration of current to drive LED 0.
+    /// </summary>
+    [Description("Specifies the configuration of current to drive LED 0.")]
+    public partial class Led0MaxCurrent : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Led0MaxCurrent"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 75;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Led0MaxCurrent"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Led0MaxCurrent"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Led0MaxCurrent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Led0MaxCurrent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Led0MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led0MaxCurrent"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Led0MaxCurrent"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led0MaxCurrent"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Led0MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Led0MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Led0MaxCurrent"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Led0MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Led0MaxCurrent"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Led0MaxCurrent register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Led0MaxCurrent register.")]
+    public partial class TimestampedLed0MaxCurrent : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Led0MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Led0MaxCurrent.Address, MessageType).Select(Led0MaxCurrent.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the configuration of current to drive LED 1.
+    /// </summary>
+    [Description("Specifies the configuration of current to drive LED 1.")]
+    public partial class Led1MaxCurrent : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Led1MaxCurrent"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 76;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Led1MaxCurrent"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Led1MaxCurrent"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Led1MaxCurrent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Led1MaxCurrent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Led1MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led1MaxCurrent"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Led1MaxCurrent"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Led1MaxCurrent"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Led1MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Led1MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Led1MaxCurrent"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Led1MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Led1MaxCurrent"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Led1MaxCurrent register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Led1MaxCurrent register.")]
+    public partial class TimestampedLed1MaxCurrent : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Led1MaxCurrent"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Led1MaxCurrent.Address, MessageType).Select(Led1MaxCurrent.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the active events in the device.
+    /// </summary>
+    [Description("Specifies the active events in the device.")]
+    public partial class EventEnable : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EventEnable"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 77;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="EventEnable"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="EventEnable"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="EventEnable"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static Events GetPayload(HarpMessage message)
+        {
+            return (Events)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="EventEnable"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<Events> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((Events)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="EventEnable"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EventEnable"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, Events value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="EventEnable"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EventEnable"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, Events value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="EventEnable"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="Events"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<Events> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="EventEnable"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="Events"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="EventEnable"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Events> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="EventEnable"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="Events"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="EventEnable"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<Events>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the EventEnable register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the EventEnable register.")]
+    public partial class TimestampedEventEnable : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="EventEnable"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="Events"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<Events>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(EventEnable.Address, MessageType).Select(EventEnable.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the camera outputs to enable in the device.
+    /// </summary>
+    [Description("Specifies the camera outputs to enable in the device.")]
+    public partial class StartCameras : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="StartCameras"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 78;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="StartCameras"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="StartCameras"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="StartCameras"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static CameraOutputs GetPayload(HarpMessage message)
+        {
+            return (CameraOutputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="StartCameras"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<CameraOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((CameraOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="StartCameras"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StartCameras"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, CameraOutputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="StartCameras"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StartCameras"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, CameraOutputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="StartCameras"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="CameraOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<CameraOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="StartCameras"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="CameraOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="StartCameras"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<CameraOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="StartCameras"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="CameraOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="StartCameras"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<CameraOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the StartCameras register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the StartCameras register.")]
+    public partial class TimestampedStartCameras : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="StartCameras"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="CameraOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<CameraOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(StartCameras.Address, MessageType).Select(StartCameras.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the camera outputs to disable in the device.
+    /// </summary>
+    [Description("Specifies the camera outputs to disable in the device.")]
+    public partial class StopCameras : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="StopCameras"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 79;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="StopCameras"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="StopCameras"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="StopCameras"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static CameraOutputs GetPayload(HarpMessage message)
+        {
+            return (CameraOutputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="StopCameras"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<CameraOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((CameraOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="StopCameras"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StopCameras"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, CameraOutputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="StopCameras"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StopCameras"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, CameraOutputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="StopCameras"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="CameraOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<CameraOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="StopCameras"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="CameraOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="StopCameras"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<CameraOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="StopCameras"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="CameraOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="StopCameras"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<CameraOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the StopCameras register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the StopCameras register.")]
+    public partial class TimestampedStopCameras : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="StopCameras"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="CameraOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<CameraOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(StopCameras.Address, MessageType).Select(StopCameras.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the servo outputs to enable in the device.
+    /// </summary>
+    [Description("Specifies the servo outputs to enable in the device.")]
+    public partial class EnableServos : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EnableServos"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 80;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="EnableServos"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="EnableServos"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="EnableServos"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ServoOutputs GetPayload(HarpMessage message)
+        {
+            return (ServoOutputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="EnableServos"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ServoOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((ServoOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="EnableServos"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EnableServos"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ServoOutputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="EnableServos"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EnableServos"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ServoOutputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="EnableServos"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ServoOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ServoOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="EnableServos"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ServoOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="EnableServos"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ServoOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="EnableServos"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ServoOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="EnableServos"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ServoOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the EnableServos register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the EnableServos register.")]
+    public partial class TimestampedEnableServos : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="EnableServos"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ServoOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ServoOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(EnableServos.Address, MessageType).Select(EnableServos.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the servo outputs to disable in the device.
+    /// </summary>
+    [Description("Specifies the servo outputs to disable in the device.")]
+    public partial class DisableServos : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="DisableServos"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 81;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="DisableServos"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="DisableServos"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="DisableServos"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ServoOutputs GetPayload(HarpMessage message)
+        {
+            return (ServoOutputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="DisableServos"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ServoOutputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((ServoOutputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="DisableServos"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="DisableServos"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ServoOutputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="DisableServos"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="DisableServos"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ServoOutputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="DisableServos"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ServoOutputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ServoOutputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="DisableServos"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ServoOutputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="DisableServos"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ServoOutputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="DisableServos"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ServoOutputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="DisableServos"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ServoOutputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the DisableServos register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the DisableServos register.")]
+    public partial class TimestampedDisableServos : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="DisableServos"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ServoOutputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ServoOutputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(DisableServos.Address, MessageType).Select(DisableServos.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the port quadrature counters to enable in the device.
+    /// </summary>
+    [Description("Specifies the port quadrature counters to enable in the device.")]
+    public partial class EnableEncoders : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EnableEncoders"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 82;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="EnableEncoders"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="EnableEncoders"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="EnableEncoders"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static EncoderInputs GetPayload(HarpMessage message)
+        {
+            return (EncoderInputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="EnableEncoders"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<EncoderInputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((EncoderInputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="EnableEncoders"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EnableEncoders"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, EncoderInputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="EnableEncoders"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EnableEncoders"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, EncoderInputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="EnableEncoders"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="EncoderInputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<EncoderInputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="EnableEncoders"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="EncoderInputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="EnableEncoders"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<EncoderInputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="EnableEncoders"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="EncoderInputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="EnableEncoders"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<EncoderInputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the EnableEncoders register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the EnableEncoders register.")]
+    public partial class TimestampedEnableEncoders : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="EnableEncoders"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="EncoderInputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<EncoderInputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(EnableEncoders.Address, MessageType).Select(EnableEncoders.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies that a frame was acquired on camera 0.
+    /// </summary>
+    [Description("Specifies that a frame was acquired on camera 0.")]
+    public partial class Camera0Frame : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Camera0Frame"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 92;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Camera0Frame"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Camera0Frame"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Camera0Frame"/> class.
+        /// </summary>
+        public Camera0Frame()
+        {
+            MessageType = MessageType.Event;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Camera0Frame"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static FrameAcquired GetPayload(HarpMessage message)
+        {
+            return (FrameAcquired)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Camera0Frame"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<FrameAcquired> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((FrameAcquired)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Camera0Frame"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera0Frame"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, FrameAcquired value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Camera0Frame"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera0Frame"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, FrameAcquired value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Camera0Frame"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="FrameAcquired"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<FrameAcquired> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Camera0Frame"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="FrameAcquired"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Camera0Frame"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<FrameAcquired> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Camera0Frame"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="FrameAcquired"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Camera0Frame"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<FrameAcquired>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Camera0Frame register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Camera0Frame register.")]
+    public partial class TimestampedCamera0Frame : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Camera0Frame"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="FrameAcquired"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<FrameAcquired>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Camera0Frame.Address, MessageType).Select(Camera0Frame.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the trigger frequency for camera 0.
+    /// </summary>
+    [Description("Specifies the trigger frequency for camera 0.")]
+    public partial class Camera0Frequency : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Camera0Frequency"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 93;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Camera0Frequency"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Camera0Frequency"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Camera0Frequency"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Camera0Frequency"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Camera0Frequency"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera0Frequency"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Camera0Frequency"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera0Frequency"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Camera0Frequency"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Camera0Frequency"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Camera0Frequency"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Camera0Frequency"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Camera0Frequency"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Camera0Frequency register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Camera0Frequency register.")]
+    public partial class TimestampedCamera0Frequency : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Camera0Frequency"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Camera0Frequency.Address, MessageType).Select(Camera0Frequency.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies that a frame was acquired on camera 1.
+    /// </summary>
+    [Description("Specifies that a frame was acquired on camera 1.")]
+    public partial class Camera1Frame : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Camera1Frame"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 94;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Camera1Frame"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Camera1Frame"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Camera1Frame"/> class.
+        /// </summary>
+        public Camera1Frame()
+        {
+            MessageType = MessageType.Event;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Camera1Frame"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static FrameAcquired GetPayload(HarpMessage message)
+        {
+            return (FrameAcquired)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Camera1Frame"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<FrameAcquired> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((FrameAcquired)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Camera1Frame"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera1Frame"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, FrameAcquired value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Camera1Frame"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera1Frame"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, FrameAcquired value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Camera1Frame"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="FrameAcquired"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<FrameAcquired> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Camera1Frame"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="FrameAcquired"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Camera1Frame"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<FrameAcquired> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Camera1Frame"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="FrameAcquired"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Camera1Frame"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<FrameAcquired>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Camera1Frame register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Camera1Frame register.")]
+    public partial class TimestampedCamera1Frame : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Camera1Frame"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="FrameAcquired"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<FrameAcquired>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Camera1Frame.Address, MessageType).Select(Camera1Frame.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the trigger frequency for camera 1.
+    /// </summary>
+    [Description("Specifies the trigger frequency for camera 1.")]
+    public partial class Camera1Frequency : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Camera1Frequency"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 95;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Camera1Frequency"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Camera1Frequency"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Camera1Frequency"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Camera1Frequency"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Camera1Frequency"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera1Frequency"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Camera1Frequency"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Camera1Frequency"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="Camera1Frequency"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="Camera1Frequency"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="Camera1Frequency"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="Camera1Frequency"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="Camera1Frequency"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the Camera1Frequency register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the Camera1Frequency register.")]
+    public partial class TimestampedCamera1Frequency : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="Camera1Frequency"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Camera1Frequency.Address, MessageType).Select(Camera1Frequency.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the period of the servo motor in DO2, in microseconds.
+    /// </summary>
+    [Description("Specifies the period of the servo motor in DO2, in microseconds.")]
+    public partial class ServoMotor2Period : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="ServoMotor2Period"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 100;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="ServoMotor2Period"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="ServoMotor2Period"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="ServoMotor2Period"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="ServoMotor2Period"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="ServoMotor2Period"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor2Period"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="ServoMotor2Period"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor2Period"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="ServoMotor2Period"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="ServoMotor2Period"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="ServoMotor2Period"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="ServoMotor2Period"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="ServoMotor2Period"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the ServoMotor2Period register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the ServoMotor2Period register.")]
+    public partial class TimestampedServoMotor2Period : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="ServoMotor2Period"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(ServoMotor2Period.Address, MessageType).Select(ServoMotor2Period.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the pulse of the servo motor in DO2, in microseconds.
+    /// </summary>
+    [Description("Specifies the pulse of the servo motor in DO2, in microseconds.")]
+    public partial class ServoMotor2Pulse : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="ServoMotor2Pulse"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 101;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="ServoMotor2Pulse"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="ServoMotor2Pulse"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="ServoMotor2Pulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="ServoMotor2Pulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="ServoMotor2Pulse"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor2Pulse"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="ServoMotor2Pulse"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor2Pulse"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="ServoMotor2Pulse"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="ServoMotor2Pulse"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="ServoMotor2Pulse"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="ServoMotor2Pulse"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="ServoMotor2Pulse"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the ServoMotor2Pulse register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the ServoMotor2Pulse register.")]
+    public partial class TimestampedServoMotor2Pulse : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="ServoMotor2Pulse"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(ServoMotor2Pulse.Address, MessageType).Select(ServoMotor2Pulse.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the period of the servo motor in DO3, in microseconds.
+    /// </summary>
+    [Description("Specifies the period of the servo motor in DO3, in microseconds.")]
+    public partial class ServoMotor3Period : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="ServoMotor3Period"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 102;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="ServoMotor3Period"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="ServoMotor3Period"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="ServoMotor3Period"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="ServoMotor3Period"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="ServoMotor3Period"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor3Period"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="ServoMotor3Period"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor3Period"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="ServoMotor3Period"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="ServoMotor3Period"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="ServoMotor3Period"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="ServoMotor3Period"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="ServoMotor3Period"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the ServoMotor3Period register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the ServoMotor3Period register.")]
+    public partial class TimestampedServoMotor3Period : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="ServoMotor3Period"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(ServoMotor3Period.Address, MessageType).Select(ServoMotor3Period.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the pulse of the servo motor in DO3, in microseconds.
+    /// </summary>
+    [Description("Specifies the pulse of the servo motor in DO3, in microseconds.")]
+    public partial class ServoMotor3Pulse : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="ServoMotor3Pulse"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 103;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="ServoMotor3Pulse"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="ServoMotor3Pulse"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="ServoMotor3Pulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="ServoMotor3Pulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="ServoMotor3Pulse"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor3Pulse"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="ServoMotor3Pulse"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="ServoMotor3Pulse"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="ServoMotor3Pulse"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<ushort> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="ServoMotor3Pulse"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="ushort"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="ServoMotor3Pulse"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<ushort> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="ServoMotor3Pulse"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="ushort"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="ServoMotor3Pulse"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the ServoMotor3Pulse register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the ServoMotor3Pulse register.")]
+    public partial class TimestampedServoMotor3Pulse : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="ServoMotor3Pulse"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="ushort"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(ServoMotor3Pulse.Address, MessageType).Select(ServoMotor3Pulse.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that reset the counter of the specified encoders to zero.
+    /// </summary>
+    [Description("Reset the counter of the specified encoders to zero.")]
+    public partial class EncoderReset : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EncoderReset"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 108;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="EncoderReset"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="EncoderReset"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="EncoderReset"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static EncoderInputs GetPayload(HarpMessage message)
+        {
+            return (EncoderInputs)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="EncoderReset"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<EncoderInputs> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((EncoderInputs)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="EncoderReset"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EncoderReset"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, EncoderInputs value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="EncoderReset"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EncoderReset"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, EncoderInputs value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="EncoderReset"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="EncoderInputs"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<EncoderInputs> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="EncoderReset"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="EncoderInputs"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="EncoderReset"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<EncoderInputs> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="EncoderReset"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="EncoderInputs"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="EncoderReset"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<EncoderInputs>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the EncoderReset register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the EncoderReset register.")]
+    public partial class TimestampedEncoderReset : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="EncoderReset"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="EncoderInputs"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<EncoderInputs>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(EncoderReset.Address, MessageType).Select(EncoderReset.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that enables the timestamp for serial TX.
+    /// </summary>
+    [Description("Enables the timestamp for serial TX.")]
+    public partial class EnableSerialTimestamp : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EnableSerialTimestamp"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 110;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="EnableSerialTimestamp"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="EnableSerialTimestamp"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="EnableSerialTimestamp"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="EnableSerialTimestamp"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="EnableSerialTimestamp"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EnableSerialTimestamp"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="EnableSerialTimestamp"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EnableSerialTimestamp"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="EnableSerialTimestamp"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="EnableSerialTimestamp"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="EnableSerialTimestamp"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="EnableSerialTimestamp"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="EnableSerialTimestamp"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the EnableSerialTimestamp register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the EnableSerialTimestamp register.")]
+    public partial class TimestampedEnableSerialTimestamp : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="EnableSerialTimestamp"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(EnableSerialTimestamp.Address, MessageType).Select(EnableSerialTimestamp.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the digital output to mimic the Port 0 IR state.
+    /// </summary>
+    [Description("Specifies the digital output to mimic the Port 0 IR state.")]
+    public partial class MimicPort0IR : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="MimicPort0IR"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 111;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="MimicPort0IR"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="MimicPort0IR"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="MimicPort0IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static MimicOutput GetPayload(HarpMessage message)
+        {
+            return (MimicOutput)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="MimicPort0IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((MimicOutput)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="MimicPort0IR"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort0IR"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="MimicPort0IR"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort0IR"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="MimicPort0IR"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="MimicPort0IR"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="MimicPort0IR"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="MimicPort0IR"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="MimicPort0IR"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the MimicPort0IR register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the MimicPort0IR register.")]
+    public partial class TimestampedMimicPort0IR : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="MimicPort0IR"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(MimicPort0IR.Address, MessageType).Select(MimicPort0IR.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the digital output to mimic the Port 1 IR state.
+    /// </summary>
+    [Description("Specifies the digital output to mimic the Port 1 IR state.")]
+    public partial class MimicPort1IR : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="MimicPort1IR"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 112;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="MimicPort1IR"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="MimicPort1IR"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="MimicPort1IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static MimicOutput GetPayload(HarpMessage message)
+        {
+            return (MimicOutput)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="MimicPort1IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((MimicOutput)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="MimicPort1IR"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort1IR"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="MimicPort1IR"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort1IR"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="MimicPort1IR"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="MimicPort1IR"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="MimicPort1IR"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="MimicPort1IR"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="MimicPort1IR"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the MimicPort1IR register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the MimicPort1IR register.")]
+    public partial class TimestampedMimicPort1IR : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="MimicPort1IR"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(MimicPort1IR.Address, MessageType).Select(MimicPort1IR.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the digital output to mimic the Port 2 IR state.
+    /// </summary>
+    [Description("Specifies the digital output to mimic the Port 2 IR state.")]
+    public partial class MimicPort2IR : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="MimicPort2IR"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 113;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="MimicPort2IR"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="MimicPort2IR"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="MimicPort2IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static MimicOutput GetPayload(HarpMessage message)
+        {
+            return (MimicOutput)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="MimicPort2IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((MimicOutput)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="MimicPort2IR"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort2IR"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="MimicPort2IR"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort2IR"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="MimicPort2IR"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="MimicPort2IR"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="MimicPort2IR"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="MimicPort2IR"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="MimicPort2IR"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the MimicPort2IR register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the MimicPort2IR register.")]
+    public partial class TimestampedMimicPort2IR : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="MimicPort2IR"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(MimicPort2IR.Address, MessageType).Select(MimicPort2IR.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the digital output to mimic the Port 0 valve state.
+    /// </summary>
+    [Description("Specifies the digital output to mimic the Port 0 valve state.")]
+    public partial class MimicPort0Valve : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="MimicPort0Valve"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 117;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="MimicPort0Valve"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="MimicPort0Valve"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="MimicPort0Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static MimicOutput GetPayload(HarpMessage message)
+        {
+            return (MimicOutput)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="MimicPort0Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((MimicOutput)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="MimicPort0Valve"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort0Valve"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="MimicPort0Valve"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort0Valve"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="MimicPort0Valve"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="MimicPort0Valve"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="MimicPort0Valve"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="MimicPort0Valve"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="MimicPort0Valve"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the MimicPort0Valve register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the MimicPort0Valve register.")]
+    public partial class TimestampedMimicPort0Valve : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="MimicPort0Valve"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(MimicPort0Valve.Address, MessageType).Select(MimicPort0Valve.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the digital output to mimic the Port 1 valve state.
+    /// </summary>
+    [Description("Specifies the digital output to mimic the Port 1 valve state.")]
+    public partial class MimicPort1Valve : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="MimicPort1Valve"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 118;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="MimicPort1Valve"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="MimicPort1Valve"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="MimicPort1Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static MimicOutput GetPayload(HarpMessage message)
+        {
+            return (MimicOutput)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="MimicPort1Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((MimicOutput)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="MimicPort1Valve"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort1Valve"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="MimicPort1Valve"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort1Valve"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="MimicPort1Valve"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="MimicPort1Valve"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="MimicPort1Valve"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="MimicPort1Valve"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="MimicPort1Valve"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the MimicPort1Valve register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the MimicPort1Valve register.")]
+    public partial class TimestampedMimicPort1Valve : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="MimicPort1Valve"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(MimicPort1Valve.Address, MessageType).Select(MimicPort1Valve.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the digital output to mimic the Port 2 valve state.
+    /// </summary>
+    [Description("Specifies the digital output to mimic the Port 2 valve state.")]
+    public partial class MimicPort2Valve : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="MimicPort2Valve"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 119;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="MimicPort2Valve"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="MimicPort2Valve"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="MimicPort2Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static MimicOutput GetPayload(HarpMessage message)
+        {
+            return (MimicOutput)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="MimicPort2Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((MimicOutput)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="MimicPort2Valve"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort2Valve"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="MimicPort2Valve"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="MimicPort2Valve"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MimicOutput value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="MimicPort2Valve"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="MimicPort2Valve"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MimicOutput"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="MimicPort2Valve"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="MimicPort2Valve"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="MimicPort2Valve"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the MimicPort2Valve register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the MimicPort2Valve register.")]
+    public partial class TimestampedMimicPort2Valve : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="MimicPort2Valve"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="MimicOutput"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(MimicPort2Valve.Address, MessageType).Select(MimicPort2Valve.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that specifies the low pass filter time value for poke inputs, in ms.
+    /// </summary>
+    [Description("Specifies the low pass filter time value for poke inputs, in ms.")]
+    public partial class PokeInputFilter : HarpCombinator
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="PokeInputFilter"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 122;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="PokeInputFilter"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="PokeInputFilter"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="PokeInputFilter"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="PokeInputFilter"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="PokeInputFilter"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PokeInputFilter"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="PokeInputFilter"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="PokeInputFilter"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+
+        /// <summary>
+        /// Filters and selects an observable sequence of messages from the
+        /// <see cref="PokeInputFilter"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </returns>
+        public IObservable<byte> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(Address, MessageType).Select(GetPayload);
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into Harp messages
+        /// for the <see cref="PokeInputFilter"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> objects representing the
+        /// message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
+        /// <see cref="PokeInputFilter"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<byte> source)
+        {
+            return source.Select(value => FromPayload(MessageType, value));
+        }
+
+        /// <summary>
+        /// Formats an observable sequence of values into timestamped Harp messages
+        /// for the <see cref="PokeInputFilter"/> register.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="byte"/> objects representing
+        /// the message payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
+        /// the <see cref="PokeInputFilter"/> register.
+        /// </returns>
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
+        {
+            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters and selects a sequence of timestamped messages
+    /// from the PokeInputFilter register.
+    /// </summary>
+    [Description("Filters and selects timestamped messages from the PokeInputFilter register.")]
+    public partial class TimestampedPokeInputFilter : HarpCombinator
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of timestamped messages from
+        /// the <see cref="PokeInputFilter"/> register.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of timestamped <see cref="byte"/> objects
+        /// representing the register payload.
+        /// </returns>
+        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Where(PokeInputFilter.Address, MessageType).Select(PokeInputFilter.GetTimestampedPayload);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator which creates standard message payloads for the
+    /// Behavior device.
+    /// </summary>
+    /// <seealso cref="CreateOutputSetPayload"/>
+    /// <seealso cref="CreateOutputClearPayload"/>
+    /// <seealso cref="CreateOutputTogglePayload"/>
+    /// <seealso cref="CreateOutputStatePayload"/>
+    /// <seealso cref="CreatePortDIOSetPayload"/>
+    /// <seealso cref="CreatePortDIOClearPayload"/>
+    /// <seealso cref="CreatePortDIOTogglePayload"/>
+    /// <seealso cref="CreatePortDIOStatePayload"/>
+    /// <seealso cref="CreatePortDIODirectionPayload"/>
+    /// <seealso cref="CreateOutputPulseEnablePayload"/>
+    /// <seealso cref="CreatePulseDOPort0Payload"/>
+    /// <seealso cref="CreatePulseDOPort1Payload"/>
+    /// <seealso cref="CreatePulseDOPort2Payload"/>
+    /// <seealso cref="CreatePulseSupplyPort0Payload"/>
+    /// <seealso cref="CreatePulseSupplyPort1Payload"/>
+    /// <seealso cref="CreatePulseSupplyPort2Payload"/>
+    /// <seealso cref="CreatePulseLed0Payload"/>
+    /// <seealso cref="CreatePulseLed1Payload"/>
+    /// <seealso cref="CreatePulseRgb0Payload"/>
+    /// <seealso cref="CreatePulseRgb1Payload"/>
+    /// <seealso cref="CreatePulseDO0Payload"/>
+    /// <seealso cref="CreatePulseDO1Payload"/>
+    /// <seealso cref="CreatePulseDO2Payload"/>
+    /// <seealso cref="CreatePulseDO3Payload"/>
+    /// <seealso cref="CreatePwmFrequencyDO0Payload"/>
+    /// <seealso cref="CreatePwmFrequencyDO1Payload"/>
+    /// <seealso cref="CreatePwmFrequencyDO2Payload"/>
+    /// <seealso cref="CreatePwmFrequencyDO3Payload"/>
+    /// <seealso cref="CreatePwmDutyCycleDO0Payload"/>
+    /// <seealso cref="CreatePwmDutyCycleDO1Payload"/>
+    /// <seealso cref="CreatePwmDutyCycleDO2Payload"/>
+    /// <seealso cref="CreatePwmDutyCycleDO3Payload"/>
+    /// <seealso cref="CreatePwmStartPayload"/>
+    /// <seealso cref="CreatePwmStopPayload"/>
+    /// <seealso cref="CreateRgbAllPayload"/>
+    /// <seealso cref="CreateRgb0Payload"/>
+    /// <seealso cref="CreateRgb1Payload"/>
+    /// <seealso cref="CreateLed0CurrentPayload"/>
+    /// <seealso cref="CreateLed1CurrentPayload"/>
+    /// <seealso cref="CreateLed0MaxCurrentPayload"/>
+    /// <seealso cref="CreateLed1MaxCurrentPayload"/>
+    /// <seealso cref="CreateEventEnablePayload"/>
+    /// <seealso cref="CreateStartCamerasPayload"/>
+    /// <seealso cref="CreateStopCamerasPayload"/>
+    /// <seealso cref="CreateEnableServosPayload"/>
+    /// <seealso cref="CreateDisableServosPayload"/>
+    /// <seealso cref="CreateEnableEncodersPayload"/>
+    /// <seealso cref="CreateCamera0FrequencyPayload"/>
+    /// <seealso cref="CreateCamera1FrequencyPayload"/>
+    /// <seealso cref="CreateServoMotor2PeriodPayload"/>
+    /// <seealso cref="CreateServoMotor2PulsePayload"/>
+    /// <seealso cref="CreateServoMotor3PeriodPayload"/>
+    /// <seealso cref="CreateServoMotor3PulsePayload"/>
+    /// <seealso cref="CreateEncoderResetPayload"/>
+    /// <seealso cref="CreateEnableSerialTimestampPayload"/>
+    /// <seealso cref="CreateMimicPort0IRPayload"/>
+    /// <seealso cref="CreateMimicPort1IRPayload"/>
+    /// <seealso cref="CreateMimicPort2IRPayload"/>
+    /// <seealso cref="CreateMimicPort0ValvePayload"/>
+    /// <seealso cref="CreateMimicPort1ValvePayload"/>
+    /// <seealso cref="CreateMimicPort2ValvePayload"/>
+    /// <seealso cref="CreatePokeInputFilterPayload"/>
+    [XmlInclude(typeof(CreateOutputSetPayload))]
+    [XmlInclude(typeof(CreateOutputClearPayload))]
+    [XmlInclude(typeof(CreateOutputTogglePayload))]
+    [XmlInclude(typeof(CreateOutputStatePayload))]
+    [XmlInclude(typeof(CreatePortDIOSetPayload))]
+    [XmlInclude(typeof(CreatePortDIOClearPayload))]
+    [XmlInclude(typeof(CreatePortDIOTogglePayload))]
+    [XmlInclude(typeof(CreatePortDIOStatePayload))]
+    [XmlInclude(typeof(CreatePortDIODirectionPayload))]
+    [XmlInclude(typeof(CreateOutputPulseEnablePayload))]
+    [XmlInclude(typeof(CreatePulseDOPort0Payload))]
+    [XmlInclude(typeof(CreatePulseDOPort1Payload))]
+    [XmlInclude(typeof(CreatePulseDOPort2Payload))]
+    [XmlInclude(typeof(CreatePulseSupplyPort0Payload))]
+    [XmlInclude(typeof(CreatePulseSupplyPort1Payload))]
+    [XmlInclude(typeof(CreatePulseSupplyPort2Payload))]
+    [XmlInclude(typeof(CreatePulseLed0Payload))]
+    [XmlInclude(typeof(CreatePulseLed1Payload))]
+    [XmlInclude(typeof(CreatePulseRgb0Payload))]
+    [XmlInclude(typeof(CreatePulseRgb1Payload))]
+    [XmlInclude(typeof(CreatePulseDO0Payload))]
+    [XmlInclude(typeof(CreatePulseDO1Payload))]
+    [XmlInclude(typeof(CreatePulseDO2Payload))]
+    [XmlInclude(typeof(CreatePulseDO3Payload))]
+    [XmlInclude(typeof(CreatePwmFrequencyDO0Payload))]
+    [XmlInclude(typeof(CreatePwmFrequencyDO1Payload))]
+    [XmlInclude(typeof(CreatePwmFrequencyDO2Payload))]
+    [XmlInclude(typeof(CreatePwmFrequencyDO3Payload))]
+    [XmlInclude(typeof(CreatePwmDutyCycleDO0Payload))]
+    [XmlInclude(typeof(CreatePwmDutyCycleDO1Payload))]
+    [XmlInclude(typeof(CreatePwmDutyCycleDO2Payload))]
+    [XmlInclude(typeof(CreatePwmDutyCycleDO3Payload))]
+    [XmlInclude(typeof(CreatePwmStartPayload))]
+    [XmlInclude(typeof(CreatePwmStopPayload))]
+    [XmlInclude(typeof(CreateRgbAllPayload))]
+    [XmlInclude(typeof(CreateRgb0Payload))]
+    [XmlInclude(typeof(CreateRgb1Payload))]
+    [XmlInclude(typeof(CreateLed0CurrentPayload))]
+    [XmlInclude(typeof(CreateLed1CurrentPayload))]
+    [XmlInclude(typeof(CreateLed0MaxCurrentPayload))]
+    [XmlInclude(typeof(CreateLed1MaxCurrentPayload))]
+    [XmlInclude(typeof(CreateEventEnablePayload))]
+    [XmlInclude(typeof(CreateStartCamerasPayload))]
+    [XmlInclude(typeof(CreateStopCamerasPayload))]
+    [XmlInclude(typeof(CreateEnableServosPayload))]
+    [XmlInclude(typeof(CreateDisableServosPayload))]
+    [XmlInclude(typeof(CreateEnableEncodersPayload))]
+    [XmlInclude(typeof(CreateCamera0FrequencyPayload))]
+    [XmlInclude(typeof(CreateCamera1FrequencyPayload))]
+    [XmlInclude(typeof(CreateServoMotor2PeriodPayload))]
+    [XmlInclude(typeof(CreateServoMotor2PulsePayload))]
+    [XmlInclude(typeof(CreateServoMotor3PeriodPayload))]
+    [XmlInclude(typeof(CreateServoMotor3PulsePayload))]
+    [XmlInclude(typeof(CreateEncoderResetPayload))]
+    [XmlInclude(typeof(CreateEnableSerialTimestampPayload))]
+    [XmlInclude(typeof(CreateMimicPort0IRPayload))]
+    [XmlInclude(typeof(CreateMimicPort1IRPayload))]
+    [XmlInclude(typeof(CreateMimicPort2IRPayload))]
+    [XmlInclude(typeof(CreateMimicPort0ValvePayload))]
+    [XmlInclude(typeof(CreateMimicPort1ValvePayload))]
+    [XmlInclude(typeof(CreateMimicPort2ValvePayload))]
+    [XmlInclude(typeof(CreatePokeInputFilterPayload))]
+    [Description("Creates standard message payloads for the Behavior device.")]
+    public partial class CreateMessage : CreateMessageBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateMessage"/> class.
+        /// </summary>
+        public CreateMessage()
+        {
+            Payload = new CreateOutputSetPayload();
+        }
+
+        string INamedElement.Name => $"{nameof(Behavior)}.{GetElementDisplayName(Payload)}";
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that set the specified digital output lines.
+    /// </summary>
+    [DisplayName("OutputSetPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that set the specified digital output lines.")]
+    public partial class CreateOutputSetPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that set the specified digital output lines.
+        /// </summary>
+        [Description("The value that set the specified digital output lines.")]
+        public DigitalOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that set the specified digital output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that set the specified digital output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => OutputSet.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that clear the specified digital output lines.
+    /// </summary>
+    [DisplayName("OutputClearPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that clear the specified digital output lines.")]
+    public partial class CreateOutputClearPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that clear the specified digital output lines.
+        /// </summary>
+        [Description("The value that clear the specified digital output lines.")]
+        public DigitalOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that clear the specified digital output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that clear the specified digital output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => OutputClear.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that toggle the specified digital output lines.
+    /// </summary>
+    [DisplayName("OutputTogglePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that toggle the specified digital output lines.")]
+    public partial class CreateOutputTogglePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that toggle the specified digital output lines.
+        /// </summary>
+        [Description("The value that toggle the specified digital output lines.")]
+        public DigitalOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that toggle the specified digital output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that toggle the specified digital output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => OutputToggle.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that write the state of all digital output lines.
+    /// </summary>
+    [DisplayName("OutputStatePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that write the state of all digital output lines.")]
+    public partial class CreateOutputStatePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that write the state of all digital output lines.
+        /// </summary>
+        [Description("The value that write the state of all digital output lines.")]
+        public DigitalOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that write the state of all digital output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that write the state of all digital output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => OutputState.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that set the specified port DIO lines.
+    /// </summary>
+    [DisplayName("PortDIOSetPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that set the specified port DIO lines.")]
+    public partial class CreatePortDIOSetPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that set the specified port DIO lines.
+        /// </summary>
+        [Description("The value that set the specified port DIO lines.")]
+        public PortDigitalIOS Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that set the specified port DIO lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that set the specified port DIO lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDIOSet.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that clear the specified port DIO lines.
+    /// </summary>
+    [DisplayName("PortDIOClearPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that clear the specified port DIO lines.")]
+    public partial class CreatePortDIOClearPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that clear the specified port DIO lines.
+        /// </summary>
+        [Description("The value that clear the specified port DIO lines.")]
+        public PortDigitalIOS Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that clear the specified port DIO lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that clear the specified port DIO lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDIOClear.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that toggle the specified port DIO lines.
+    /// </summary>
+    [DisplayName("PortDIOTogglePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that toggle the specified port DIO lines.")]
+    public partial class CreatePortDIOTogglePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that toggle the specified port DIO lines.
+        /// </summary>
+        [Description("The value that toggle the specified port DIO lines.")]
+        public PortDigitalIOS Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that toggle the specified port DIO lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that toggle the specified port DIO lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDIOToggle.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that write the state of all port DIO lines.
+    /// </summary>
+    [DisplayName("PortDIOStatePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that write the state of all port DIO lines.")]
+    public partial class CreatePortDIOStatePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that write the state of all port DIO lines.
+        /// </summary>
+        [Description("The value that write the state of all port DIO lines.")]
+        public PortDigitalIOS Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that write the state of all port DIO lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that write the state of all port DIO lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDIOState.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies which of the port DIO lines are outputs.
+    /// </summary>
+    [DisplayName("PortDIODirectionPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies which of the port DIO lines are outputs.")]
+    public partial class CreatePortDIODirectionPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies which of the port DIO lines are outputs.
+        /// </summary>
+        [Description("The value that specifies which of the port DIO lines are outputs.")]
+        public PortDigitalIOS Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies which of the port DIO lines are outputs.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies which of the port DIO lines are outputs.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDIODirection.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that enables the pulse function for the specified output lines.
+    /// </summary>
+    [DisplayName("OutputPulseEnablePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that enables the pulse function for the specified output lines.")]
+    public partial class CreateOutputPulseEnablePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that enables the pulse function for the specified output lines.
+        /// </summary>
+        [Description("The value that enables the pulse function for the specified output lines.")]
+        public DigitalOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that enables the pulse function for the specified output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that enables the pulse function for the specified output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => OutputPulseEnable.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDOPort0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDOPort0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDOPort0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDOPort1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDOPort1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDOPort1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDOPort2Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDOPort2Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDOPort2.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseSupplyPort0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseSupplyPort0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseSupplyPort0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseSupplyPort1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseSupplyPort1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseSupplyPort1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseSupplyPort2Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseSupplyPort2Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseSupplyPort2.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseLed0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseLed0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseLed0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseLed1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseLed1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseLed1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseRgb0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseRgb0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseRgb0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseRgb1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseRgb1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseRgb1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDO0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDO0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDO0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDO1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDO1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDO1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDO2Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDO2Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDO2.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duration of the output pulse in milliseconds.
+    /// </summary>
+    [DisplayName("PulseDO3Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duration of the output pulse in milliseconds.")]
+    public partial class CreatePulseDO3Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duration of the output pulse in milliseconds.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duration of the output pulse in milliseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PulseDO3.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the frequency of the PWM at DO0.
+    /// </summary>
+    [DisplayName("PwmFrequencyDO0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the frequency of the PWM at DO0.")]
+    public partial class CreatePwmFrequencyDO0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the frequency of the PWM at DO0.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the frequency of the PWM at DO0.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the frequency of the PWM at DO0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the frequency of the PWM at DO0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmFrequencyDO0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the frequency of the PWM at DO1.
+    /// </summary>
+    [DisplayName("PwmFrequencyDO1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the frequency of the PWM at DO1.")]
+    public partial class CreatePwmFrequencyDO1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the frequency of the PWM at DO1.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the frequency of the PWM at DO1.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the frequency of the PWM at DO1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the frequency of the PWM at DO1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmFrequencyDO1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the frequency of the PWM at DO2.
+    /// </summary>
+    [DisplayName("PwmFrequencyDO2Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the frequency of the PWM at DO2.")]
+    public partial class CreatePwmFrequencyDO2Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the frequency of the PWM at DO2.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the frequency of the PWM at DO2.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the frequency of the PWM at DO2.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the frequency of the PWM at DO2.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmFrequencyDO2.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the frequency of the PWM at DO3.
+    /// </summary>
+    [DisplayName("PwmFrequencyDO3Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the frequency of the PWM at DO3.")]
+    public partial class CreatePwmFrequencyDO3Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the frequency of the PWM at DO3.
+        /// </summary>
+        [Range(min: 1, max: long.MaxValue)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the frequency of the PWM at DO3.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the frequency of the PWM at DO3.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the frequency of the PWM at DO3.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmFrequencyDO3.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duty cycle of the PWM at DO0.
+    /// </summary>
+    [DisplayName("PwmDutyCycleDO0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duty cycle of the PWM at DO0.")]
+    public partial class CreatePwmDutyCycleDO0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duty cycle of the PWM at DO0.
+        /// </summary>
+        [Range(min: 1, max: 99)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duty cycle of the PWM at DO0.")]
+        public byte Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duty cycle of the PWM at DO0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duty cycle of the PWM at DO0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmDutyCycleDO0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duty cycle of the PWM at DO1.
+    /// </summary>
+    [DisplayName("PwmDutyCycleDO1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duty cycle of the PWM at DO1.")]
+    public partial class CreatePwmDutyCycleDO1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duty cycle of the PWM at DO1.
+        /// </summary>
+        [Range(min: 1, max: 99)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duty cycle of the PWM at DO1.")]
+        public byte Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duty cycle of the PWM at DO1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duty cycle of the PWM at DO1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmDutyCycleDO1.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duty cycle of the PWM at DO2.
+    /// </summary>
+    [DisplayName("PwmDutyCycleDO2Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duty cycle of the PWM at DO2.")]
+    public partial class CreatePwmDutyCycleDO2Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duty cycle of the PWM at DO2.
+        /// </summary>
+        [Range(min: 1, max: 99)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duty cycle of the PWM at DO2.")]
+        public byte Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duty cycle of the PWM at DO2.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duty cycle of the PWM at DO2.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmDutyCycleDO2.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the duty cycle of the PWM at DO3.
+    /// </summary>
+    [DisplayName("PwmDutyCycleDO3Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the duty cycle of the PWM at DO3.")]
+    public partial class CreatePwmDutyCycleDO3Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the duty cycle of the PWM at DO3.
+        /// </summary>
+        [Range(min: 1, max: 99)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the duty cycle of the PWM at DO3.")]
+        public byte Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the duty cycle of the PWM at DO3.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the duty cycle of the PWM at DO3.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmDutyCycleDO3.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that starts the PWM on the selected output lines.
+    /// </summary>
+    [DisplayName("PwmStartPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that starts the PWM on the selected output lines.")]
+    public partial class CreatePwmStartPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that starts the PWM on the selected output lines.
+        /// </summary>
+        [Description("The value that starts the PWM on the selected output lines.")]
+        public PwmOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that starts the PWM on the selected output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that starts the PWM on the selected output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmStart.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that stops the PWM on the selected output lines.
+    /// </summary>
+    [DisplayName("PwmStopPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that stops the PWM on the selected output lines.")]
+    public partial class CreatePwmStopPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that stops the PWM on the selected output lines.
+        /// </summary>
+        [Range(min: 1, max: 99)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that stops the PWM on the selected output lines.")]
+        public byte Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that stops the PWM on the selected output lines.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that stops the PWM on the selected output lines.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PwmStop.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the state of all RGB LED channels.
+    /// </summary>
+    [DisplayName("RgbAllPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the state of all RGB LED channels.")]
+    public partial class CreateRgbAllPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets a value that the intensity of the green channel in the RGB0 LED.
+        /// </summary>
+        [Description("The intensity of the green channel in the RGB0 LED.")]
+        public byte Green0 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the red channel in the RGB0 LED.
+        /// </summary>
+        [Description("The intensity of the red channel in the RGB0 LED.")]
+        public byte Red0 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the blue channel in the RGB0 LED.
+        /// </summary>
+        [Description("The intensity of the blue channel in the RGB0 LED.")]
+        public byte Blue0 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the green channel in the RGB1 LED.
+        /// </summary>
+        [Description("The intensity of the green channel in the RGB1 LED.")]
+        public byte Green1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the red channel in the RGB1 LED.
+        /// </summary>
+        [Description("The intensity of the red channel in the RGB1 LED.")]
+        public byte Red1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the blue channel in the RGB1 LED.
+        /// </summary>
+        [Description("The intensity of the blue channel in the RGB1 LED.")]
+        public byte Blue1 { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the state of all RGB LED channels.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the state of all RGB LED channels.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ =>
+            {
+                RgbAllPayload value;
+                value.Green0 = Green0;
+                value.Red0 = Red0;
+                value.Blue0 = Blue0;
+                value.Green1 = Green1;
+                value.Red1 = Red1;
+                value.Blue1 = Blue1;
+                return RgbAll.FromPayload(MessageType, value);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the state of the RGB0 LED channels.
+    /// </summary>
+    [DisplayName("Rgb0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the state of the RGB0 LED channels.")]
+    public partial class CreateRgb0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets a value that the intensity of the green channel in the RGB LED.
+        /// </summary>
+        [Description("The intensity of the green channel in the RGB LED.")]
+        public byte Green { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the red channel in the RGB LED.
+        /// </summary>
+        [Description("The intensity of the red channel in the RGB LED.")]
+        public byte Red { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the blue channel in the RGB LED.
+        /// </summary>
+        [Description("The intensity of the blue channel in the RGB LED.")]
+        public byte Blue { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the state of the RGB0 LED channels.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the state of the RGB0 LED channels.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ =>
+            {
+                RgbPayload value;
+                value.Green = Green;
+                value.Red = Red;
+                value.Blue = Blue;
+                return Rgb0.FromPayload(MessageType, value);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the state of the RGB1 LED channels.
+    /// </summary>
+    [DisplayName("Rgb1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the state of the RGB1 LED channels.")]
+    public partial class CreateRgb1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets a value that the intensity of the green channel in the RGB LED.
+        /// </summary>
+        [Description("The intensity of the green channel in the RGB LED.")]
+        public byte Green { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the red channel in the RGB LED.
+        /// </summary>
+        [Description("The intensity of the red channel in the RGB LED.")]
+        public byte Red { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the intensity of the blue channel in the RGB LED.
+        /// </summary>
+        [Description("The intensity of the blue channel in the RGB LED.")]
+        public byte Blue { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the state of the RGB1 LED channels.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the state of the RGB1 LED channels.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ =>
+            {
+                RgbPayload value;
+                value.Green = Green;
+                value.Red = Red;
+                value.Blue = Blue;
+                return Rgb1.FromPayload(MessageType, value);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the configuration of current to drive LED 0.
+    /// </summary>
+    [DisplayName("Led0CurrentPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the configuration of current to drive LED 0.")]
+    public partial class CreateLed0CurrentPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the configuration of current to drive LED 0.
+        /// </summary>
+        [Range(min: 2, max: 100)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the configuration of current to drive LED 0.")]
+        public byte Value { get; set; } = 2;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the configuration of current to drive LED 0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the configuration of current to drive LED 0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Led0Current.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the configuration of current to drive LED 1.
+    /// </summary>
+    [DisplayName("Led1CurrentPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the configuration of current to drive LED 1.")]
+    public partial class CreateLed1CurrentPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the configuration of current to drive LED 1.
+        /// </summary>
+        [Range(min: 2, max: 100)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the configuration of current to drive LED 1.")]
+        public byte Value { get; set; } = 2;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the configuration of current to drive LED 1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the configuration of current to drive LED 1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Led1Current.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the configuration of current to drive LED 0.
+    /// </summary>
+    [DisplayName("Led0MaxCurrentPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the configuration of current to drive LED 0.")]
+    public partial class CreateLed0MaxCurrentPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the configuration of current to drive LED 0.
+        /// </summary>
+        [Range(min: 5, max: 100)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the configuration of current to drive LED 0.")]
+        public byte Value { get; set; } = 5;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the configuration of current to drive LED 0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the configuration of current to drive LED 0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Led0MaxCurrent.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the configuration of current to drive LED 1.
+    /// </summary>
+    [DisplayName("Led1MaxCurrentPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the configuration of current to drive LED 1.")]
+    public partial class CreateLed1MaxCurrentPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the configuration of current to drive LED 1.
+        /// </summary>
+        [Range(min: 5, max: 100)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the configuration of current to drive LED 1.")]
+        public byte Value { get; set; } = 5;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the configuration of current to drive LED 1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the configuration of current to drive LED 1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Led1MaxCurrent.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the active events in the device.
+    /// </summary>
+    [DisplayName("EventEnablePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the active events in the device.")]
+    public partial class CreateEventEnablePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the active events in the device.
+        /// </summary>
+        [Description("The value that specifies the active events in the device.")]
+        public Events Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the active events in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the active events in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => EventEnable.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the camera outputs to enable in the device.
+    /// </summary>
+    [DisplayName("StartCamerasPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the camera outputs to enable in the device.")]
+    public partial class CreateStartCamerasPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the camera outputs to enable in the device.
+        /// </summary>
+        [Description("The value that specifies the camera outputs to enable in the device.")]
+        public CameraOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the camera outputs to enable in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the camera outputs to enable in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => StartCameras.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the camera outputs to disable in the device.
+    /// </summary>
+    [DisplayName("StopCamerasPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the camera outputs to disable in the device.")]
+    public partial class CreateStopCamerasPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the camera outputs to disable in the device.
+        /// </summary>
+        [Description("The value that specifies the camera outputs to disable in the device.")]
+        public CameraOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the camera outputs to disable in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the camera outputs to disable in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => StopCameras.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the servo outputs to enable in the device.
+    /// </summary>
+    [DisplayName("EnableServosPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the servo outputs to enable in the device.")]
+    public partial class CreateEnableServosPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the servo outputs to enable in the device.
+        /// </summary>
+        [Description("The value that specifies the servo outputs to enable in the device.")]
+        public ServoOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the servo outputs to enable in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the servo outputs to enable in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => EnableServos.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the servo outputs to disable in the device.
+    /// </summary>
+    [DisplayName("DisableServosPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the servo outputs to disable in the device.")]
+    public partial class CreateDisableServosPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the servo outputs to disable in the device.
+        /// </summary>
+        [Description("The value that specifies the servo outputs to disable in the device.")]
+        public ServoOutputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the servo outputs to disable in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the servo outputs to disable in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => DisableServos.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the port quadrature counters to enable in the device.
+    /// </summary>
+    [DisplayName("EnableEncodersPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the port quadrature counters to enable in the device.")]
+    public partial class CreateEnableEncodersPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the port quadrature counters to enable in the device.
+        /// </summary>
+        [Description("The value that specifies the port quadrature counters to enable in the device.")]
+        public EncoderInputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the port quadrature counters to enable in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the port quadrature counters to enable in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => EnableEncoders.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the trigger frequency for camera 0.
+    /// </summary>
+    [DisplayName("Camera0FrequencyPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the trigger frequency for camera 0.")]
+    public partial class CreateCamera0FrequencyPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the trigger frequency for camera 0.
+        /// </summary>
+        [Range(min: 1, max: 600)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the trigger frequency for camera 0.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the trigger frequency for camera 0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the trigger frequency for camera 0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Camera0Frequency.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the trigger frequency for camera 1.
+    /// </summary>
+    [DisplayName("Camera1FrequencyPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the trigger frequency for camera 1.")]
+    public partial class CreateCamera1FrequencyPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the trigger frequency for camera 1.
+        /// </summary>
+        [Range(min: 1, max: 600)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("The value that specifies the trigger frequency for camera 1.")]
+        public ushort Value { get; set; } = 1;
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the trigger frequency for camera 1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the trigger frequency for camera 1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Camera1Frequency.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the period of the servo motor in DO2, in microseconds.
+    /// </summary>
+    [DisplayName("ServoMotor2PeriodPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the period of the servo motor in DO2, in microseconds.")]
+    public partial class CreateServoMotor2PeriodPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the period of the servo motor in DO2, in microseconds.
+        /// </summary>
+        [Description("The value that specifies the period of the servo motor in DO2, in microseconds.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the period of the servo motor in DO2, in microseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the period of the servo motor in DO2, in microseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => ServoMotor2Period.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the pulse of the servo motor in DO2, in microseconds.
+    /// </summary>
+    [DisplayName("ServoMotor2PulsePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the pulse of the servo motor in DO2, in microseconds.")]
+    public partial class CreateServoMotor2PulsePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the pulse of the servo motor in DO2, in microseconds.
+        /// </summary>
+        [Description("The value that specifies the pulse of the servo motor in DO2, in microseconds.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the pulse of the servo motor in DO2, in microseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the pulse of the servo motor in DO2, in microseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => ServoMotor2Pulse.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the period of the servo motor in DO3, in microseconds.
+    /// </summary>
+    [DisplayName("ServoMotor3PeriodPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the period of the servo motor in DO3, in microseconds.")]
+    public partial class CreateServoMotor3PeriodPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the period of the servo motor in DO3, in microseconds.
+        /// </summary>
+        [Description("The value that specifies the period of the servo motor in DO3, in microseconds.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the period of the servo motor in DO3, in microseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the period of the servo motor in DO3, in microseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => ServoMotor3Period.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the pulse of the servo motor in DO3, in microseconds.
+    /// </summary>
+    [DisplayName("ServoMotor3PulsePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the pulse of the servo motor in DO3, in microseconds.")]
+    public partial class CreateServoMotor3PulsePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the pulse of the servo motor in DO3, in microseconds.
+        /// </summary>
+        [Description("The value that specifies the pulse of the servo motor in DO3, in microseconds.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the pulse of the servo motor in DO3, in microseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the pulse of the servo motor in DO3, in microseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => ServoMotor3Pulse.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that reset the counter of the specified encoders to zero.
+    /// </summary>
+    [DisplayName("EncoderResetPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that reset the counter of the specified encoders to zero.")]
+    public partial class CreateEncoderResetPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that reset the counter of the specified encoders to zero.
+        /// </summary>
+        [Description("The value that reset the counter of the specified encoders to zero.")]
+        public EncoderInputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that reset the counter of the specified encoders to zero.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that reset the counter of the specified encoders to zero.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => EncoderReset.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that enables the timestamp for serial TX.
+    /// </summary>
+    [DisplayName("EnableSerialTimestampPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that enables the timestamp for serial TX.")]
+    public partial class CreateEnableSerialTimestampPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that enables the timestamp for serial TX.
+        /// </summary>
+        [Description("The value that enables the timestamp for serial TX.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that enables the timestamp for serial TX.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that enables the timestamp for serial TX.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => EnableSerialTimestamp.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the digital output to mimic the Port 0 IR state.
+    /// </summary>
+    [DisplayName("MimicPort0IRPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the digital output to mimic the Port 0 IR state.")]
+    public partial class CreateMimicPort0IRPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the digital output to mimic the Port 0 IR state.
+        /// </summary>
+        [Description("The value that specifies the digital output to mimic the Port 0 IR state.")]
+        public MimicOutput Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the digital output to mimic the Port 0 IR state.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the digital output to mimic the Port 0 IR state.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => MimicPort0IR.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the digital output to mimic the Port 1 IR state.
+    /// </summary>
+    [DisplayName("MimicPort1IRPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the digital output to mimic the Port 1 IR state.")]
+    public partial class CreateMimicPort1IRPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the digital output to mimic the Port 1 IR state.
+        /// </summary>
+        [Description("The value that specifies the digital output to mimic the Port 1 IR state.")]
+        public MimicOutput Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the digital output to mimic the Port 1 IR state.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the digital output to mimic the Port 1 IR state.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => MimicPort1IR.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the digital output to mimic the Port 2 IR state.
+    /// </summary>
+    [DisplayName("MimicPort2IRPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the digital output to mimic the Port 2 IR state.")]
+    public partial class CreateMimicPort2IRPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the digital output to mimic the Port 2 IR state.
+        /// </summary>
+        [Description("The value that specifies the digital output to mimic the Port 2 IR state.")]
+        public MimicOutput Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the digital output to mimic the Port 2 IR state.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the digital output to mimic the Port 2 IR state.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => MimicPort2IR.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the digital output to mimic the Port 0 valve state.
+    /// </summary>
+    [DisplayName("MimicPort0ValvePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the digital output to mimic the Port 0 valve state.")]
+    public partial class CreateMimicPort0ValvePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the digital output to mimic the Port 0 valve state.
+        /// </summary>
+        [Description("The value that specifies the digital output to mimic the Port 0 valve state.")]
+        public MimicOutput Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the digital output to mimic the Port 0 valve state.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the digital output to mimic the Port 0 valve state.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => MimicPort0Valve.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the digital output to mimic the Port 1 valve state.
+    /// </summary>
+    [DisplayName("MimicPort1ValvePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the digital output to mimic the Port 1 valve state.")]
+    public partial class CreateMimicPort1ValvePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the digital output to mimic the Port 1 valve state.
+        /// </summary>
+        [Description("The value that specifies the digital output to mimic the Port 1 valve state.")]
+        public MimicOutput Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the digital output to mimic the Port 1 valve state.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the digital output to mimic the Port 1 valve state.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => MimicPort1Valve.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the digital output to mimic the Port 2 valve state.
+    /// </summary>
+    [DisplayName("MimicPort2ValvePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the digital output to mimic the Port 2 valve state.")]
+    public partial class CreateMimicPort2ValvePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the digital output to mimic the Port 2 valve state.
+        /// </summary>
+        [Description("The value that specifies the digital output to mimic the Port 2 valve state.")]
+        public MimicOutput Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the digital output to mimic the Port 2 valve state.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the digital output to mimic the Port 2 valve state.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => MimicPort2Valve.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the low pass filter time value for poke inputs, in ms.
+    /// </summary>
+    [DisplayName("PokeInputFilterPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the low pass filter time value for poke inputs, in ms.")]
+    public partial class CreatePokeInputFilterPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the low pass filter time value for poke inputs, in ms.
+        /// </summary>
+        [Description("The value that specifies the low pass filter time value for poke inputs, in ms.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the low pass filter time value for poke inputs, in ms.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the low pass filter time value for poke inputs, in ms.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PokeInputFilter.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents the payload of the AnalogData register.
+    /// </summary>
+    public struct AnalogDataPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnalogDataPayload"/> structure.
+        /// </summary>
+        /// <param name="analogInput">The voltage at the output of the ADC</param>
+        /// <param name="encoder">The quadrature counter value on Port 2</param>
+        public AnalogDataPayload(
+            short analogInput,
+            short encoder)
+        {
+            AnalogInput = analogInput;
+            Encoder = encoder;
+        }
+
+        /// <summary>
+        /// The voltage at the output of the ADC
+        /// </summary>
+        public short AnalogInput;
+
+        /// <summary>
+        /// The quadrature counter value on Port 2
+        /// </summary>
+        public short Encoder;
+    }
+
+    /// <summary>
+    /// Represents the payload of the RgbAll register.
+    /// </summary>
+    public struct RgbAllPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RgbAllPayload"/> structure.
+        /// </summary>
+        /// <param name="green0">The intensity of the green channel in the RGB0 LED.</param>
+        /// <param name="red0">The intensity of the red channel in the RGB0 LED.</param>
+        /// <param name="blue0">The intensity of the blue channel in the RGB0 LED.</param>
+        /// <param name="green1">The intensity of the green channel in the RGB1 LED.</param>
+        /// <param name="red1">The intensity of the red channel in the RGB1 LED.</param>
+        /// <param name="blue1">The intensity of the blue channel in the RGB1 LED.</param>
+        public RgbAllPayload(
+            byte green0,
+            byte red0,
+            byte blue0,
+            byte green1,
+            byte red1,
+            byte blue1)
+        {
+            Green0 = green0;
+            Red0 = red0;
+            Blue0 = blue0;
+            Green1 = green1;
+            Red1 = red1;
+            Blue1 = blue1;
+        }
+
+        /// <summary>
+        /// The intensity of the green channel in the RGB0 LED.
+        /// </summary>
+        public byte Green0;
+
+        /// <summary>
+        /// The intensity of the red channel in the RGB0 LED.
+        /// </summary>
+        public byte Red0;
+
+        /// <summary>
+        /// The intensity of the blue channel in the RGB0 LED.
+        /// </summary>
+        public byte Blue0;
+
+        /// <summary>
+        /// The intensity of the green channel in the RGB1 LED.
+        /// </summary>
+        public byte Green1;
+
+        /// <summary>
+        /// The intensity of the red channel in the RGB1 LED.
+        /// </summary>
+        public byte Red1;
+
+        /// <summary>
+        /// The intensity of the blue channel in the RGB1 LED.
+        /// </summary>
+        public byte Blue1;
+    }
+
+    /// <summary>
+    /// Represents the payload of the Rgb register.
+    /// </summary>
+    public struct RgbPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RgbPayload"/> structure.
+        /// </summary>
+        /// <param name="green">The intensity of the green channel in the RGB LED.</param>
+        /// <param name="red">The intensity of the red channel in the RGB LED.</param>
+        /// <param name="blue">The intensity of the blue channel in the RGB LED.</param>
+        public RgbPayload(
+            byte green,
+            byte red,
+            byte blue)
+        {
+            Green = green;
+            Red = red;
+            Blue = blue;
+        }
+
+        /// <summary>
+        /// The intensity of the green channel in the RGB LED.
+        /// </summary>
+        public byte Green;
+
+        /// <summary>
+        /// The intensity of the red channel in the RGB LED.
+        /// </summary>
+        public byte Red;
+
+        /// <summary>
+        /// The intensity of the blue channel in the RGB LED.
+        /// </summary>
+        public byte Blue;
+    }
+
+    /// <summary>
+    /// Specifies the state of port digital input lines.
+    /// </summary>
+    [Flags]
+    public enum DigitalInputs : byte
+    {
+        DI0 = 0x1,
+        DI1 = 0x2,
+        DI2 = 0x4,
+        DI3 = 0x8
+    }
+
+    /// <summary>
+    /// Specifies the state of port digital output lines.
+    /// </summary>
+    [Flags]
+    public enum DigitalOutputs : ushort
+    {
+        DOPort0 = 0x1,
+        DOPort1 = 0x2,
+        DOPort2 = 0x4,
+        SupplyPort0 = 0x8,
+        SupplyPort1 = 0x10,
+        SupplyPort2 = 0x20,
+        Led0 = 0x40,
+        Led1 = 0x80,
+        Rgb0 = 0x100,
+        Rgb1 = 0x200,
+        DO0 = 0x400,
+        DO1 = 0x800,
+        DO2 = 0x1000,
+        DO3 = 0x2000
+    }
+
+    /// <summary>
+    /// Specifies the state of the port DIO lines.
+    /// </summary>
+    [Flags]
+    public enum PortDigitalIOS : byte
+    {
+        DIO0 = 0x1,
+        DIO1 = 0x2,
+        DIO2 = 0x4
+    }
+
+    /// <summary>
+    /// Specifies the state of PWM output lines.
+    /// </summary>
+    [Flags]
+    public enum PwmOutputs : byte
+    {
+        PwmDO0 = 0x1,
+        PwmDO1 = 0x2,
+        PwmDO2 = 0x4,
+        PwmDO3 = 0x8
+    }
+
+    /// <summary>
+    /// Specifies the active events in the device.
+    /// </summary>
+    [Flags]
+    public enum Events : byte
+    {
+        PortDI = 0x1,
+        PortDIO = 0x2,
+        AnalogData = 0x4,
+        Camera0 = 0x8,
+        Camera1 = 0x10
+    }
+
+    /// <summary>
+    /// Specifies camera output enable bits.
+    /// </summary>
+    [Flags]
+    public enum CameraOutputs : byte
+    {
+        CameraOutput0 = 0x1,
+        CameraOutput1 = 0x2
+    }
+
+    /// <summary>
+    /// Specifies servo output enable bits.
+    /// </summary>
+    [Flags]
+    public enum ServoOutputs : byte
+    {
+        ServoOutput2 = 0x4,
+        ServoOutput3 = 0x8
+    }
+
+    /// <summary>
+    /// Specifies quadrature counter enable bits.
+    /// </summary>
+    [Flags]
+    public enum EncoderInputs : byte
+    {
+        EncoderPort2 = 0x4
+    }
+
+    /// <summary>
+    /// Specifies that camera frame was acquired.
+    /// </summary>
+    [Flags]
+    public enum FrameAcquired : byte
+    {
+        FrameAcquired = 0x1
+    }
+
+    /// <summary>
+    /// Specifies the target IO on which to mimic the specified register.
+    /// </summary>
+    public enum MimicOutput : byte
+    {
+        None = 0,
+        DIO0 = 1,
+        DIO1 = 2,
+        DIO2 = 3,
+        DO0 = 4,
+        DO1 = 5,
+        DO2 = 6,
+        DO3 = 7
+    }
+}

--- a/Interface/Harp.Behavior/Device.Generated.cs
+++ b/Interface/Harp.Behavior/Device.Generated.cs
@@ -32,97 +32,97 @@ namespace Harp.Behavior
         string INamedElement.Name => nameof(Behavior);
 
         /// <summary>
-        /// Gets a read-only mapping from address to register name.
+        /// Gets a read-only mapping from address to register type.
         /// </summary>
-        public static new IReadOnlyDictionary<int, string> RegisterMap { get; } = new Dictionary<int, string>
+        public static new IReadOnlyDictionary<int, Type> RegisterMap { get; } = new Dictionary<int, Type>
             (Bonsai.Harp.Device.RegisterMap.ToDictionary(entry => entry.Key, entry => entry.Value))
         {
-            { 32, "PortDigitalInput" },
-            { 34, "OutputSet" },
-            { 35, "OutputClear" },
-            { 36, "OutputToggle" },
-            { 37, "OutputState" },
-            { 38, "PortDIOSet" },
-            { 39, "PortDIOClear" },
-            { 40, "PortDIOToggle" },
-            { 41, "PortDIOState" },
-            { 42, "PortDIODirection" },
-            { 43, "PortDIOStateEvent" },
-            { 44, "AnalogData" },
-            { 45, "OutputPulseEnable" },
-            { 46, "PulseDOPort0" },
-            { 47, "PulseDOPort1" },
-            { 48, "PulseDOPort2" },
-            { 49, "PulseSupplyPort0" },
-            { 50, "PulseSupplyPort1" },
-            { 51, "PulseSupplyPort2" },
-            { 52, "PulseLed0" },
-            { 53, "PulseLed1" },
-            { 54, "PulseRgb0" },
-            { 55, "PulseRgb1" },
-            { 56, "PulseDO0" },
-            { 57, "PulseDO1" },
-            { 58, "PulseDO2" },
-            { 59, "PulseDO3" },
-            { 60, "PwmFrequencyDO0" },
-            { 61, "PwmFrequencyDO1" },
-            { 62, "PwmFrequencyDO2" },
-            { 63, "PwmFrequencyDO3" },
-            { 64, "PwmDutyCycleDO0" },
-            { 65, "PwmDutyCycleDO1" },
-            { 66, "PwmDutyCycleDO2" },
-            { 67, "PwmDutyCycleDO3" },
-            { 68, "PwmStart" },
-            { 69, "PwmStop" },
-            { 70, "RgbAll" },
-            { 71, "Rgb0" },
-            { 72, "Rgb1" },
-            { 73, "Led0Current" },
-            { 74, "Led1Current" },
-            { 75, "Led0MaxCurrent" },
-            { 76, "Led1MaxCurrent" },
-            { 77, "EventEnable" },
-            { 78, "StartCameras" },
-            { 79, "StopCameras" },
-            { 80, "EnableServos" },
-            { 81, "DisableServos" },
-            { 82, "EnableEncoders" },
-            { 92, "Camera0Frame" },
-            { 93, "Camera0Frequency" },
-            { 94, "Camera1Frame" },
-            { 95, "Camera1Frequency" },
-            { 100, "ServoMotor2Period" },
-            { 101, "ServoMotor2Pulse" },
-            { 102, "ServoMotor3Period" },
-            { 103, "ServoMotor3Pulse" },
-            { 108, "EncoderReset" },
-            { 110, "EnableSerialTimestamp" },
-            { 111, "MimicPort0IR" },
-            { 112, "MimicPort1IR" },
-            { 113, "MimicPort2IR" },
-            { 117, "MimicPort0Valve" },
-            { 118, "MimicPort1Valve" },
-            { 119, "MimicPort2Valve" },
-            { 122, "PokeInputFilter" }
+            { 32, typeof(PortDigitalInput) },
+            { 34, typeof(OutputSet) },
+            { 35, typeof(OutputClear) },
+            { 36, typeof(OutputToggle) },
+            { 37, typeof(OutputState) },
+            { 38, typeof(PortDIOSet) },
+            { 39, typeof(PortDIOClear) },
+            { 40, typeof(PortDIOToggle) },
+            { 41, typeof(PortDIOState) },
+            { 42, typeof(PortDIODirection) },
+            { 43, typeof(PortDIOStateEvent) },
+            { 44, typeof(AnalogData) },
+            { 45, typeof(OutputPulseEnable) },
+            { 46, typeof(PulseDOPort0) },
+            { 47, typeof(PulseDOPort1) },
+            { 48, typeof(PulseDOPort2) },
+            { 49, typeof(PulseSupplyPort0) },
+            { 50, typeof(PulseSupplyPort1) },
+            { 51, typeof(PulseSupplyPort2) },
+            { 52, typeof(PulseLed0) },
+            { 53, typeof(PulseLed1) },
+            { 54, typeof(PulseRgb0) },
+            { 55, typeof(PulseRgb1) },
+            { 56, typeof(PulseDO0) },
+            { 57, typeof(PulseDO1) },
+            { 58, typeof(PulseDO2) },
+            { 59, typeof(PulseDO3) },
+            { 60, typeof(PwmFrequencyDO0) },
+            { 61, typeof(PwmFrequencyDO1) },
+            { 62, typeof(PwmFrequencyDO2) },
+            { 63, typeof(PwmFrequencyDO3) },
+            { 64, typeof(PwmDutyCycleDO0) },
+            { 65, typeof(PwmDutyCycleDO1) },
+            { 66, typeof(PwmDutyCycleDO2) },
+            { 67, typeof(PwmDutyCycleDO3) },
+            { 68, typeof(PwmStart) },
+            { 69, typeof(PwmStop) },
+            { 70, typeof(RgbAll) },
+            { 71, typeof(Rgb0) },
+            { 72, typeof(Rgb1) },
+            { 73, typeof(Led0Current) },
+            { 74, typeof(Led1Current) },
+            { 75, typeof(Led0MaxCurrent) },
+            { 76, typeof(Led1MaxCurrent) },
+            { 77, typeof(EventEnable) },
+            { 78, typeof(StartCameras) },
+            { 79, typeof(StopCameras) },
+            { 80, typeof(EnableServos) },
+            { 81, typeof(DisableServos) },
+            { 82, typeof(EnableEncoders) },
+            { 92, typeof(Camera0Frame) },
+            { 93, typeof(Camera0Frequency) },
+            { 94, typeof(Camera1Frame) },
+            { 95, typeof(Camera1Frequency) },
+            { 100, typeof(ServoMotor2Period) },
+            { 101, typeof(ServoMotor2Pulse) },
+            { 102, typeof(ServoMotor3Period) },
+            { 103, typeof(ServoMotor3Pulse) },
+            { 108, typeof(EncoderReset) },
+            { 110, typeof(EnableSerialTimestamp) },
+            { 111, typeof(MimicPort0IR) },
+            { 112, typeof(MimicPort1IR) },
+            { 113, typeof(MimicPort2IR) },
+            { 117, typeof(MimicPort0Valve) },
+            { 118, typeof(MimicPort1Valve) },
+            { 119, typeof(MimicPort2Valve) },
+            { 122, typeof(PokeInputFilter) }
         };
     }
 
     /// <summary>
-    /// Represents an operator that groups the sequence of <see cref="Behavior"/>" messages by register name.
+    /// Represents an operator that groups the sequence of <see cref="Behavior"/>" messages by register type.
     /// </summary>
-    [Description("Groups the sequence of Behavior messages by register name.")]
-    public partial class GroupByRegister : Combinator<HarpMessage, IGroupedObservable<string, HarpMessage>>
+    [Description("Groups the sequence of Behavior messages by register type.")]
+    public partial class GroupByRegister : Combinator<HarpMessage, IGroupedObservable<Type, HarpMessage>>
     {
         /// <summary>
         /// Groups an observable sequence of <see cref="Behavior"/> messages
-        /// by register name.
+        /// by register type.
         /// </summary>
         /// <param name="source">The sequence of Harp device messages.</param>
         /// <returns>
         /// A sequence of observable groups, each of which corresponds to a unique
         /// <see cref="Behavior"/> register.
         /// </returns>
-        public override IObservable<IGroupedObservable<string, HarpMessage>> Process(IObservable<HarpMessage> source)
+        public override IObservable<IGroupedObservable<Type, HarpMessage>> Process(IObservable<HarpMessage> source)
         {
             return source.GroupBy(message => Device.RegisterMap[message.Address]);
         }
@@ -132,82 +132,154 @@ namespace Harp.Behavior
     /// Represents an operator that filters register-specific messages
     /// reported by the <see cref="Behavior"/> device.
     /// </summary>
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDigitalInput>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputSet>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputClear>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputToggle>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputState>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOSet>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOClear>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOToggle>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOState>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIODirection>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PortDIOStateEvent>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<AnalogData>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<OutputPulseEnable>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDOPort0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDOPort1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDOPort2>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseSupplyPort0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseSupplyPort1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseSupplyPort2>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseLed0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseLed1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseRgb0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseRgb1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO2>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PulseDO3>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO2>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmFrequencyDO3>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO2>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmDutyCycleDO3>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmStart>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PwmStop>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<RgbAll>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Rgb0>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Rgb1>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led0Current>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led1Current>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led0MaxCurrent>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Led1MaxCurrent>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EventEnable>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<StartCameras>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<StopCameras>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EnableServos>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<DisableServos>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EnableEncoders>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera0Frame>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera0Frequency>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera1Frame>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<Camera1Frequency>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor2Period>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor2Pulse>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor3Period>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<ServoMotor3Pulse>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EncoderReset>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<EnableSerialTimestamp>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort0IR>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort1IR>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort2IR>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort0Valve>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort1Valve>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<MimicPort2Valve>))]
-    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<PokeInputFilter>))]
+    /// <seealso cref="PortDigitalInput"/>
+    /// <seealso cref="OutputSet"/>
+    /// <seealso cref="OutputClear"/>
+    /// <seealso cref="OutputToggle"/>
+    /// <seealso cref="OutputState"/>
+    /// <seealso cref="PortDIOSet"/>
+    /// <seealso cref="PortDIOClear"/>
+    /// <seealso cref="PortDIOToggle"/>
+    /// <seealso cref="PortDIOState"/>
+    /// <seealso cref="PortDIODirection"/>
+    /// <seealso cref="PortDIOStateEvent"/>
+    /// <seealso cref="AnalogData"/>
+    /// <seealso cref="OutputPulseEnable"/>
+    /// <seealso cref="PulseDOPort0"/>
+    /// <seealso cref="PulseDOPort1"/>
+    /// <seealso cref="PulseDOPort2"/>
+    /// <seealso cref="PulseSupplyPort0"/>
+    /// <seealso cref="PulseSupplyPort1"/>
+    /// <seealso cref="PulseSupplyPort2"/>
+    /// <seealso cref="PulseLed0"/>
+    /// <seealso cref="PulseLed1"/>
+    /// <seealso cref="PulseRgb0"/>
+    /// <seealso cref="PulseRgb1"/>
+    /// <seealso cref="PulseDO0"/>
+    /// <seealso cref="PulseDO1"/>
+    /// <seealso cref="PulseDO2"/>
+    /// <seealso cref="PulseDO3"/>
+    /// <seealso cref="PwmFrequencyDO0"/>
+    /// <seealso cref="PwmFrequencyDO1"/>
+    /// <seealso cref="PwmFrequencyDO2"/>
+    /// <seealso cref="PwmFrequencyDO3"/>
+    /// <seealso cref="PwmDutyCycleDO0"/>
+    /// <seealso cref="PwmDutyCycleDO1"/>
+    /// <seealso cref="PwmDutyCycleDO2"/>
+    /// <seealso cref="PwmDutyCycleDO3"/>
+    /// <seealso cref="PwmStart"/>
+    /// <seealso cref="PwmStop"/>
+    /// <seealso cref="RgbAll"/>
+    /// <seealso cref="Rgb0"/>
+    /// <seealso cref="Rgb1"/>
+    /// <seealso cref="Led0Current"/>
+    /// <seealso cref="Led1Current"/>
+    /// <seealso cref="Led0MaxCurrent"/>
+    /// <seealso cref="Led1MaxCurrent"/>
+    /// <seealso cref="EventEnable"/>
+    /// <seealso cref="StartCameras"/>
+    /// <seealso cref="StopCameras"/>
+    /// <seealso cref="EnableServos"/>
+    /// <seealso cref="DisableServos"/>
+    /// <seealso cref="EnableEncoders"/>
+    /// <seealso cref="Camera0Frame"/>
+    /// <seealso cref="Camera0Frequency"/>
+    /// <seealso cref="Camera1Frame"/>
+    /// <seealso cref="Camera1Frequency"/>
+    /// <seealso cref="ServoMotor2Period"/>
+    /// <seealso cref="ServoMotor2Pulse"/>
+    /// <seealso cref="ServoMotor3Period"/>
+    /// <seealso cref="ServoMotor3Pulse"/>
+    /// <seealso cref="EncoderReset"/>
+    /// <seealso cref="EnableSerialTimestamp"/>
+    /// <seealso cref="MimicPort0IR"/>
+    /// <seealso cref="MimicPort1IR"/>
+    /// <seealso cref="MimicPort2IR"/>
+    /// <seealso cref="MimicPort0Valve"/>
+    /// <seealso cref="MimicPort1Valve"/>
+    /// <seealso cref="MimicPort2Valve"/>
+    /// <seealso cref="PokeInputFilter"/>
+    [XmlInclude(typeof(PortDigitalInput))]
+    [XmlInclude(typeof(OutputSet))]
+    [XmlInclude(typeof(OutputClear))]
+    [XmlInclude(typeof(OutputToggle))]
+    [XmlInclude(typeof(OutputState))]
+    [XmlInclude(typeof(PortDIOSet))]
+    [XmlInclude(typeof(PortDIOClear))]
+    [XmlInclude(typeof(PortDIOToggle))]
+    [XmlInclude(typeof(PortDIOState))]
+    [XmlInclude(typeof(PortDIODirection))]
+    [XmlInclude(typeof(PortDIOStateEvent))]
+    [XmlInclude(typeof(AnalogData))]
+    [XmlInclude(typeof(OutputPulseEnable))]
+    [XmlInclude(typeof(PulseDOPort0))]
+    [XmlInclude(typeof(PulseDOPort1))]
+    [XmlInclude(typeof(PulseDOPort2))]
+    [XmlInclude(typeof(PulseSupplyPort0))]
+    [XmlInclude(typeof(PulseSupplyPort1))]
+    [XmlInclude(typeof(PulseSupplyPort2))]
+    [XmlInclude(typeof(PulseLed0))]
+    [XmlInclude(typeof(PulseLed1))]
+    [XmlInclude(typeof(PulseRgb0))]
+    [XmlInclude(typeof(PulseRgb1))]
+    [XmlInclude(typeof(PulseDO0))]
+    [XmlInclude(typeof(PulseDO1))]
+    [XmlInclude(typeof(PulseDO2))]
+    [XmlInclude(typeof(PulseDO3))]
+    [XmlInclude(typeof(PwmFrequencyDO0))]
+    [XmlInclude(typeof(PwmFrequencyDO1))]
+    [XmlInclude(typeof(PwmFrequencyDO2))]
+    [XmlInclude(typeof(PwmFrequencyDO3))]
+    [XmlInclude(typeof(PwmDutyCycleDO0))]
+    [XmlInclude(typeof(PwmDutyCycleDO1))]
+    [XmlInclude(typeof(PwmDutyCycleDO2))]
+    [XmlInclude(typeof(PwmDutyCycleDO3))]
+    [XmlInclude(typeof(PwmStart))]
+    [XmlInclude(typeof(PwmStop))]
+    [XmlInclude(typeof(RgbAll))]
+    [XmlInclude(typeof(Rgb0))]
+    [XmlInclude(typeof(Rgb1))]
+    [XmlInclude(typeof(Led0Current))]
+    [XmlInclude(typeof(Led1Current))]
+    [XmlInclude(typeof(Led0MaxCurrent))]
+    [XmlInclude(typeof(Led1MaxCurrent))]
+    [XmlInclude(typeof(EventEnable))]
+    [XmlInclude(typeof(StartCameras))]
+    [XmlInclude(typeof(StopCameras))]
+    [XmlInclude(typeof(EnableServos))]
+    [XmlInclude(typeof(DisableServos))]
+    [XmlInclude(typeof(EnableEncoders))]
+    [XmlInclude(typeof(Camera0Frame))]
+    [XmlInclude(typeof(Camera0Frequency))]
+    [XmlInclude(typeof(Camera1Frame))]
+    [XmlInclude(typeof(Camera1Frequency))]
+    [XmlInclude(typeof(ServoMotor2Period))]
+    [XmlInclude(typeof(ServoMotor2Pulse))]
+    [XmlInclude(typeof(ServoMotor3Period))]
+    [XmlInclude(typeof(ServoMotor3Pulse))]
+    [XmlInclude(typeof(EncoderReset))]
+    [XmlInclude(typeof(EnableSerialTimestamp))]
+    [XmlInclude(typeof(MimicPort0IR))]
+    [XmlInclude(typeof(MimicPort1IR))]
+    [XmlInclude(typeof(MimicPort2IR))]
+    [XmlInclude(typeof(MimicPort0Valve))]
+    [XmlInclude(typeof(MimicPort1Valve))]
+    [XmlInclude(typeof(MimicPort2Valve))]
+    [XmlInclude(typeof(PokeInputFilter))]
     [Description("Filters register-specific messages reported by the Behavior device.")]
-    public class FilterMessage : FilterMessageBuilder
+    public class FilterMessage : FilterMessageBuilder, INamedElement
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FilterMessage"/> class.
         /// </summary>
         public FilterMessage()
         {
-            Register = new Bonsai.Expressions.TypeMapping<PortDigitalInput>();
+            Register = new PortDigitalInput();
+        }
+
+        string INamedElement.Name
+        {
+            get => $"{nameof(Behavior)}.{GetElementDisplayName(Register)}";
         }
     }
 
@@ -583,10 +655,10 @@ namespace Harp.Behavior
     }
 
     /// <summary>
-    /// Represents an operator that reflects the state of DI digital lines of each Port.
+    /// Represents a register that reflects the state of DI digital lines of each Port.
     /// </summary>
     [Description("Reflects the state of DI digital lines of each Port")]
-    public partial class PortDigitalInput : HarpCombinator
+    public partial class PortDigitalInput
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDigitalInput"/> register. This field is constant.
@@ -602,14 +674,6 @@ namespace Harp.Behavior
         /// Represents the length of the <see cref="PortDigitalInput"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PortDigitalInput"/> class.
-        /// </summary>
-        public PortDigitalInput()
-        {
-            MessageType = MessageType.Event;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="PortDigitalInput"/> register messages.
@@ -661,83 +725,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDigitalInput"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="DigitalInputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<DigitalInputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDigitalInput"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="DigitalInputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDigitalInput"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<DigitalInputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDigitalInput"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="DigitalInputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDigitalInput"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalInputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDigitalInput register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDigitalInput register.
     /// </summary>
+    /// <seealso cref="PortDigitalInput"/>
     [Description("Filters and selects timestamped messages from the PortDigitalInput register.")]
-    public partial class TimestampedPortDigitalInput : HarpCombinator
+    public partial class TimestampedPortDigitalInput
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDigitalInput"/> register.
+        /// Represents the address of the <see cref="PortDigitalInput"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="DigitalInputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<DigitalInputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDigitalInput.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDigitalInput"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalInputs> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDigitalInput.Address, MessageType).Select(PortDigitalInput.GetTimestampedPayload);
+            return PortDigitalInput.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that set the specified digital output lines.
+    /// Represents a register that set the specified digital output lines.
     /// </summary>
     [Description("Set the specified digital output lines.")]
-    public partial class OutputSet : HarpCombinator
+    public partial class OutputSet
     {
         /// <summary>
         /// Represents the address of the <see cref="OutputSet"/> register. This field is constant.
@@ -804,83 +822,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="OutputSet"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="OutputSet"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="OutputSet"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="OutputSet"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="OutputSet"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the OutputSet register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// OutputSet register.
     /// </summary>
+    /// <seealso cref="OutputSet"/>
     [Description("Filters and selects timestamped messages from the OutputSet register.")]
-    public partial class TimestampedOutputSet : HarpCombinator
+    public partial class TimestampedOutputSet
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="OutputSet"/> register.
+        /// Represents the address of the <see cref="OutputSet"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = OutputSet.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="OutputSet"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(OutputSet.Address, MessageType).Select(OutputSet.GetTimestampedPayload);
+            return OutputSet.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that clear the specified digital output lines.
+    /// Represents a register that clear the specified digital output lines.
     /// </summary>
     [Description("Clear the specified digital output lines")]
-    public partial class OutputClear : HarpCombinator
+    public partial class OutputClear
     {
         /// <summary>
         /// Represents the address of the <see cref="OutputClear"/> register. This field is constant.
@@ -947,83 +919,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="OutputClear"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="OutputClear"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="OutputClear"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="OutputClear"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="OutputClear"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the OutputClear register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// OutputClear register.
     /// </summary>
+    /// <seealso cref="OutputClear"/>
     [Description("Filters and selects timestamped messages from the OutputClear register.")]
-    public partial class TimestampedOutputClear : HarpCombinator
+    public partial class TimestampedOutputClear
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="OutputClear"/> register.
+        /// Represents the address of the <see cref="OutputClear"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = OutputClear.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="OutputClear"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(OutputClear.Address, MessageType).Select(OutputClear.GetTimestampedPayload);
+            return OutputClear.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that toggle the specified digital output lines.
+    /// Represents a register that toggle the specified digital output lines.
     /// </summary>
     [Description("Toggle the specified digital output lines")]
-    public partial class OutputToggle : HarpCombinator
+    public partial class OutputToggle
     {
         /// <summary>
         /// Represents the address of the <see cref="OutputToggle"/> register. This field is constant.
@@ -1090,83 +1016,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="OutputToggle"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="OutputToggle"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="OutputToggle"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="OutputToggle"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="OutputToggle"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the OutputToggle register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// OutputToggle register.
     /// </summary>
+    /// <seealso cref="OutputToggle"/>
     [Description("Filters and selects timestamped messages from the OutputToggle register.")]
-    public partial class TimestampedOutputToggle : HarpCombinator
+    public partial class TimestampedOutputToggle
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="OutputToggle"/> register.
+        /// Represents the address of the <see cref="OutputToggle"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = OutputToggle.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="OutputToggle"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(OutputToggle.Address, MessageType).Select(OutputToggle.GetTimestampedPayload);
+            return OutputToggle.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that write the state of all digital output lines.
+    /// Represents a register that write the state of all digital output lines.
     /// </summary>
     [Description("Write the state of all digital output lines")]
-    public partial class OutputState : HarpCombinator
+    public partial class OutputState
     {
         /// <summary>
         /// Represents the address of the <see cref="OutputState"/> register. This field is constant.
@@ -1233,83 +1113,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="OutputState"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="OutputState"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="OutputState"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="OutputState"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="OutputState"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the OutputState register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// OutputState register.
     /// </summary>
+    /// <seealso cref="OutputState"/>
     [Description("Filters and selects timestamped messages from the OutputState register.")]
-    public partial class TimestampedOutputState : HarpCombinator
+    public partial class TimestampedOutputState
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="OutputState"/> register.
+        /// Represents the address of the <see cref="OutputState"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = OutputState.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="OutputState"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(OutputState.Address, MessageType).Select(OutputState.GetTimestampedPayload);
+            return OutputState.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that set the specified port DIO lines.
+    /// Represents a register that set the specified port DIO lines.
     /// </summary>
     [Description("Set the specified port DIO lines")]
-    public partial class PortDIOSet : HarpCombinator
+    public partial class PortDIOSet
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDIOSet"/> register. This field is constant.
@@ -1376,83 +1210,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDIOSet"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDIOSet"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDIOSet"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDIOSet"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDIOSet"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDIOSet register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDIOSet register.
     /// </summary>
+    /// <seealso cref="PortDIOSet"/>
     [Description("Filters and selects timestamped messages from the PortDIOSet register.")]
-    public partial class TimestampedPortDIOSet : HarpCombinator
+    public partial class TimestampedPortDIOSet
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDIOSet"/> register.
+        /// Represents the address of the <see cref="PortDIOSet"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDIOSet.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDIOSet"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDIOSet.Address, MessageType).Select(PortDIOSet.GetTimestampedPayload);
+            return PortDIOSet.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that clear the specified port DIO lines.
+    /// Represents a register that clear the specified port DIO lines.
     /// </summary>
     [Description("Clear the specified port DIO lines")]
-    public partial class PortDIOClear : HarpCombinator
+    public partial class PortDIOClear
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDIOClear"/> register. This field is constant.
@@ -1519,83 +1307,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDIOClear"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDIOClear"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDIOClear"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDIOClear"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDIOClear"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDIOClear register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDIOClear register.
     /// </summary>
+    /// <seealso cref="PortDIOClear"/>
     [Description("Filters and selects timestamped messages from the PortDIOClear register.")]
-    public partial class TimestampedPortDIOClear : HarpCombinator
+    public partial class TimestampedPortDIOClear
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDIOClear"/> register.
+        /// Represents the address of the <see cref="PortDIOClear"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDIOClear.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDIOClear"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDIOClear.Address, MessageType).Select(PortDIOClear.GetTimestampedPayload);
+            return PortDIOClear.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that toggle the specified port DIO lines.
+    /// Represents a register that toggle the specified port DIO lines.
     /// </summary>
     [Description("Toggle the specified port DIO lines")]
-    public partial class PortDIOToggle : HarpCombinator
+    public partial class PortDIOToggle
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDIOToggle"/> register. This field is constant.
@@ -1662,83 +1404,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDIOToggle"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDIOToggle"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDIOToggle"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDIOToggle"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDIOToggle"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDIOToggle register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDIOToggle register.
     /// </summary>
+    /// <seealso cref="PortDIOToggle"/>
     [Description("Filters and selects timestamped messages from the PortDIOToggle register.")]
-    public partial class TimestampedPortDIOToggle : HarpCombinator
+    public partial class TimestampedPortDIOToggle
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDIOToggle"/> register.
+        /// Represents the address of the <see cref="PortDIOToggle"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDIOToggle.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDIOToggle"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDIOToggle.Address, MessageType).Select(PortDIOToggle.GetTimestampedPayload);
+            return PortDIOToggle.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that write the state of all port DIO lines.
+    /// Represents a register that write the state of all port DIO lines.
     /// </summary>
     [Description("Write the state of all port DIO lines")]
-    public partial class PortDIOState : HarpCombinator
+    public partial class PortDIOState
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDIOState"/> register. This field is constant.
@@ -1805,83 +1501,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDIOState"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDIOState"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDIOState"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDIOState"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDIOState"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDIOState register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDIOState register.
     /// </summary>
+    /// <seealso cref="PortDIOState"/>
     [Description("Filters and selects timestamped messages from the PortDIOState register.")]
-    public partial class TimestampedPortDIOState : HarpCombinator
+    public partial class TimestampedPortDIOState
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDIOState"/> register.
+        /// Represents the address of the <see cref="PortDIOState"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDIOState.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDIOState"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDIOState.Address, MessageType).Select(PortDIOState.GetTimestampedPayload);
+            return PortDIOState.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies which of the port DIO lines are outputs.
+    /// Represents a register that specifies which of the port DIO lines are outputs.
     /// </summary>
     [Description("Specifies which of the port DIO lines are outputs")]
-    public partial class PortDIODirection : HarpCombinator
+    public partial class PortDIODirection
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDIODirection"/> register. This field is constant.
@@ -1948,83 +1598,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDIODirection"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDIODirection"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDIODirection"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDIODirection"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDIODirection"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDIODirection register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDIODirection register.
     /// </summary>
+    /// <seealso cref="PortDIODirection"/>
     [Description("Filters and selects timestamped messages from the PortDIODirection register.")]
-    public partial class TimestampedPortDIODirection : HarpCombinator
+    public partial class TimestampedPortDIODirection
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDIODirection"/> register.
+        /// Represents the address of the <see cref="PortDIODirection"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDIODirection.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDIODirection"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDIODirection.Address, MessageType).Select(PortDIODirection.GetTimestampedPayload);
+            return PortDIODirection.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the state of the port DIO lines on a line change.
+    /// Represents a register that specifies the state of the port DIO lines on a line change.
     /// </summary>
     [Description("Specifies the state of the port DIO lines on a line change")]
-    public partial class PortDIOStateEvent : HarpCombinator
+    public partial class PortDIOStateEvent
     {
         /// <summary>
         /// Represents the address of the <see cref="PortDIOStateEvent"/> register. This field is constant.
@@ -2040,14 +1644,6 @@ namespace Harp.Behavior
         /// Represents the length of the <see cref="PortDIOStateEvent"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PortDIOStateEvent"/> class.
-        /// </summary>
-        public PortDIOStateEvent()
-        {
-            MessageType = MessageType.Event;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="PortDIOStateEvent"/> register messages.
@@ -2099,83 +1695,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PortDIOStateEvent"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PortDigitalIOS> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PortDIOStateEvent"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PortDigitalIOS"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PortDIOStateEvent"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PortDigitalIOS> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PortDIOStateEvent"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PortDIOStateEvent"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PortDigitalIOS>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PortDIOStateEvent register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PortDIOStateEvent register.
     /// </summary>
+    /// <seealso cref="PortDIOStateEvent"/>
     [Description("Filters and selects timestamped messages from the PortDIOStateEvent register.")]
-    public partial class TimestampedPortDIOStateEvent : HarpCombinator
+    public partial class TimestampedPortDIOStateEvent
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PortDIOStateEvent"/> register.
+        /// Represents the address of the <see cref="PortDIOStateEvent"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PortDigitalIOS"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PortDigitalIOS>> Process(IObservable<HarpMessage> source)
+        public const int Address = PortDIOStateEvent.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PortDIOStateEvent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PortDigitalIOS> GetPayload(HarpMessage message)
         {
-            return source.Where(PortDIOStateEvent.Address, MessageType).Select(PortDIOStateEvent.GetTimestampedPayload);
+            return PortDIOStateEvent.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that voltage at the ADC input and encoder value on Port 2.
+    /// Represents a register that voltage at the ADC input and encoder value on Port 2.
     /// </summary>
     [Description("Voltage at the ADC input and encoder value on Port 2")]
-    public partial class AnalogData : HarpCombinator
+    public partial class AnalogData
     {
         /// <summary>
         /// Represents the address of the <see cref="AnalogData"/> register. This field is constant.
@@ -2191,14 +1741,6 @@ namespace Harp.Behavior
         /// Represents the length of the <see cref="AnalogData"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 2;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AnalogData"/> class.
-        /// </summary>
-        public AnalogData()
-        {
-            MessageType = MessageType.Event;
-        }
 
         static AnalogDataPayload ParsePayload(short[] payload)
         {
@@ -2267,83 +1809,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromInt16(Address, timestamp, messageType, FormatPayload(value));
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="AnalogData"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="AnalogDataPayload"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<AnalogDataPayload> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="AnalogData"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="AnalogDataPayload"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="AnalogData"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<AnalogDataPayload> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="AnalogData"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="AnalogDataPayload"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="AnalogData"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<AnalogDataPayload>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the AnalogData register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// AnalogData register.
     /// </summary>
+    /// <seealso cref="AnalogData"/>
     [Description("Filters and selects timestamped messages from the AnalogData register.")]
-    public partial class TimestampedAnalogData : HarpCombinator
+    public partial class TimestampedAnalogData
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="AnalogData"/> register.
+        /// Represents the address of the <see cref="AnalogData"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="AnalogDataPayload"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<AnalogDataPayload>> Process(IObservable<HarpMessage> source)
+        public const int Address = AnalogData.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="AnalogData"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<AnalogDataPayload> GetPayload(HarpMessage message)
         {
-            return source.Where(AnalogData.Address, MessageType).Select(AnalogData.GetTimestampedPayload);
+            return AnalogData.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that enables the pulse function for the specified output lines.
+    /// Represents a register that enables the pulse function for the specified output lines.
     /// </summary>
     [Description("Enables the pulse function for the specified output lines")]
-    public partial class OutputPulseEnable : HarpCombinator
+    public partial class OutputPulseEnable
     {
         /// <summary>
         /// Represents the address of the <see cref="OutputPulseEnable"/> register. This field is constant.
@@ -2410,83 +1906,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="OutputPulseEnable"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<DigitalOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="OutputPulseEnable"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="DigitalOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="OutputPulseEnable"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<DigitalOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="OutputPulseEnable"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="OutputPulseEnable"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<DigitalOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the OutputPulseEnable register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// OutputPulseEnable register.
     /// </summary>
+    /// <seealso cref="OutputPulseEnable"/>
     [Description("Filters and selects timestamped messages from the OutputPulseEnable register.")]
-    public partial class TimestampedOutputPulseEnable : HarpCombinator
+    public partial class TimestampedOutputPulseEnable
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="OutputPulseEnable"/> register.
+        /// Represents the address of the <see cref="OutputPulseEnable"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="DigitalOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<DigitalOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = OutputPulseEnable.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="OutputPulseEnable"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<DigitalOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(OutputPulseEnable.Address, MessageType).Select(OutputPulseEnable.GetTimestampedPayload);
+            return OutputPulseEnable.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDOPort0 : HarpCombinator
+    public partial class PulseDOPort0
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDOPort0"/> register. This field is constant.
@@ -2552,83 +2002,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDOPort0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDOPort0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDOPort0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDOPort0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDOPort0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDOPort0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDOPort0 register.
     /// </summary>
+    /// <seealso cref="PulseDOPort0"/>
     [Description("Filters and selects timestamped messages from the PulseDOPort0 register.")]
-    public partial class TimestampedPulseDOPort0 : HarpCombinator
+    public partial class TimestampedPulseDOPort0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDOPort0"/> register.
+        /// Represents the address of the <see cref="PulseDOPort0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDOPort0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDOPort0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDOPort0.Address, MessageType).Select(PulseDOPort0.GetTimestampedPayload);
+            return PulseDOPort0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDOPort1 : HarpCombinator
+    public partial class PulseDOPort1
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDOPort1"/> register. This field is constant.
@@ -2694,83 +2098,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDOPort1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDOPort1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDOPort1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDOPort1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDOPort1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDOPort1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDOPort1 register.
     /// </summary>
+    /// <seealso cref="PulseDOPort1"/>
     [Description("Filters and selects timestamped messages from the PulseDOPort1 register.")]
-    public partial class TimestampedPulseDOPort1 : HarpCombinator
+    public partial class TimestampedPulseDOPort1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDOPort1"/> register.
+        /// Represents the address of the <see cref="PulseDOPort1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDOPort1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDOPort1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDOPort1.Address, MessageType).Select(PulseDOPort1.GetTimestampedPayload);
+            return PulseDOPort1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDOPort2 : HarpCombinator
+    public partial class PulseDOPort2
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDOPort2"/> register. This field is constant.
@@ -2836,83 +2194,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDOPort2"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDOPort2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDOPort2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDOPort2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDOPort2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDOPort2 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDOPort2 register.
     /// </summary>
+    /// <seealso cref="PulseDOPort2"/>
     [Description("Filters and selects timestamped messages from the PulseDOPort2 register.")]
-    public partial class TimestampedPulseDOPort2 : HarpCombinator
+    public partial class TimestampedPulseDOPort2
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDOPort2"/> register.
+        /// Represents the address of the <see cref="PulseDOPort2"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDOPort2.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDOPort2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDOPort2.Address, MessageType).Select(PulseDOPort2.GetTimestampedPayload);
+            return PulseDOPort2.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseSupplyPort0 : HarpCombinator
+    public partial class PulseSupplyPort0
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseSupplyPort0"/> register. This field is constant.
@@ -2978,83 +2290,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseSupplyPort0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseSupplyPort0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseSupplyPort0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseSupplyPort0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseSupplyPort0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseSupplyPort0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseSupplyPort0 register.
     /// </summary>
+    /// <seealso cref="PulseSupplyPort0"/>
     [Description("Filters and selects timestamped messages from the PulseSupplyPort0 register.")]
-    public partial class TimestampedPulseSupplyPort0 : HarpCombinator
+    public partial class TimestampedPulseSupplyPort0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseSupplyPort0"/> register.
+        /// Represents the address of the <see cref="PulseSupplyPort0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseSupplyPort0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseSupplyPort0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseSupplyPort0.Address, MessageType).Select(PulseSupplyPort0.GetTimestampedPayload);
+            return PulseSupplyPort0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseSupplyPort1 : HarpCombinator
+    public partial class PulseSupplyPort1
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseSupplyPort1"/> register. This field is constant.
@@ -3120,83 +2386,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseSupplyPort1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseSupplyPort1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseSupplyPort1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseSupplyPort1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseSupplyPort1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseSupplyPort1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseSupplyPort1 register.
     /// </summary>
+    /// <seealso cref="PulseSupplyPort1"/>
     [Description("Filters and selects timestamped messages from the PulseSupplyPort1 register.")]
-    public partial class TimestampedPulseSupplyPort1 : HarpCombinator
+    public partial class TimestampedPulseSupplyPort1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseSupplyPort1"/> register.
+        /// Represents the address of the <see cref="PulseSupplyPort1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseSupplyPort1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseSupplyPort1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseSupplyPort1.Address, MessageType).Select(PulseSupplyPort1.GetTimestampedPayload);
+            return PulseSupplyPort1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseSupplyPort2 : HarpCombinator
+    public partial class PulseSupplyPort2
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseSupplyPort2"/> register. This field is constant.
@@ -3262,83 +2482,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseSupplyPort2"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseSupplyPort2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseSupplyPort2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseSupplyPort2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseSupplyPort2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseSupplyPort2 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseSupplyPort2 register.
     /// </summary>
+    /// <seealso cref="PulseSupplyPort2"/>
     [Description("Filters and selects timestamped messages from the PulseSupplyPort2 register.")]
-    public partial class TimestampedPulseSupplyPort2 : HarpCombinator
+    public partial class TimestampedPulseSupplyPort2
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseSupplyPort2"/> register.
+        /// Represents the address of the <see cref="PulseSupplyPort2"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseSupplyPort2.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseSupplyPort2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseSupplyPort2.Address, MessageType).Select(PulseSupplyPort2.GetTimestampedPayload);
+            return PulseSupplyPort2.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseLed0 : HarpCombinator
+    public partial class PulseLed0
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseLed0"/> register. This field is constant.
@@ -3404,83 +2578,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseLed0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseLed0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseLed0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseLed0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseLed0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseLed0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseLed0 register.
     /// </summary>
+    /// <seealso cref="PulseLed0"/>
     [Description("Filters and selects timestamped messages from the PulseLed0 register.")]
-    public partial class TimestampedPulseLed0 : HarpCombinator
+    public partial class TimestampedPulseLed0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseLed0"/> register.
+        /// Represents the address of the <see cref="PulseLed0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseLed0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseLed0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseLed0.Address, MessageType).Select(PulseLed0.GetTimestampedPayload);
+            return PulseLed0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseLed1 : HarpCombinator
+    public partial class PulseLed1
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseLed1"/> register. This field is constant.
@@ -3546,83 +2674,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseLed1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseLed1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseLed1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseLed1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseLed1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseLed1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseLed1 register.
     /// </summary>
+    /// <seealso cref="PulseLed1"/>
     [Description("Filters and selects timestamped messages from the PulseLed1 register.")]
-    public partial class TimestampedPulseLed1 : HarpCombinator
+    public partial class TimestampedPulseLed1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseLed1"/> register.
+        /// Represents the address of the <see cref="PulseLed1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseLed1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseLed1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseLed1.Address, MessageType).Select(PulseLed1.GetTimestampedPayload);
+            return PulseLed1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseRgb0 : HarpCombinator
+    public partial class PulseRgb0
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseRgb0"/> register. This field is constant.
@@ -3688,83 +2770,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseRgb0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseRgb0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseRgb0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseRgb0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseRgb0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseRgb0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseRgb0 register.
     /// </summary>
+    /// <seealso cref="PulseRgb0"/>
     [Description("Filters and selects timestamped messages from the PulseRgb0 register.")]
-    public partial class TimestampedPulseRgb0 : HarpCombinator
+    public partial class TimestampedPulseRgb0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseRgb0"/> register.
+        /// Represents the address of the <see cref="PulseRgb0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseRgb0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseRgb0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseRgb0.Address, MessageType).Select(PulseRgb0.GetTimestampedPayload);
+            return PulseRgb0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseRgb1 : HarpCombinator
+    public partial class PulseRgb1
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseRgb1"/> register. This field is constant.
@@ -3830,83 +2866,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseRgb1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseRgb1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseRgb1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseRgb1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseRgb1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseRgb1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseRgb1 register.
     /// </summary>
+    /// <seealso cref="PulseRgb1"/>
     [Description("Filters and selects timestamped messages from the PulseRgb1 register.")]
-    public partial class TimestampedPulseRgb1 : HarpCombinator
+    public partial class TimestampedPulseRgb1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseRgb1"/> register.
+        /// Represents the address of the <see cref="PulseRgb1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseRgb1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseRgb1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseRgb1.Address, MessageType).Select(PulseRgb1.GetTimestampedPayload);
+            return PulseRgb1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDO0 : HarpCombinator
+    public partial class PulseDO0
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDO0"/> register. This field is constant.
@@ -3972,83 +2962,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDO0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDO0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDO0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDO0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDO0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDO0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDO0 register.
     /// </summary>
+    /// <seealso cref="PulseDO0"/>
     [Description("Filters and selects timestamped messages from the PulseDO0 register.")]
-    public partial class TimestampedPulseDO0 : HarpCombinator
+    public partial class TimestampedPulseDO0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDO0"/> register.
+        /// Represents the address of the <see cref="PulseDO0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDO0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDO0.Address, MessageType).Select(PulseDO0.GetTimestampedPayload);
+            return PulseDO0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDO1 : HarpCombinator
+    public partial class PulseDO1
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDO1"/> register. This field is constant.
@@ -4114,83 +3058,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDO1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDO1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDO1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDO1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDO1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDO1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDO1 register.
     /// </summary>
+    /// <seealso cref="PulseDO1"/>
     [Description("Filters and selects timestamped messages from the PulseDO1 register.")]
-    public partial class TimestampedPulseDO1 : HarpCombinator
+    public partial class TimestampedPulseDO1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDO1"/> register.
+        /// Represents the address of the <see cref="PulseDO1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDO1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDO1.Address, MessageType).Select(PulseDO1.GetTimestampedPayload);
+            return PulseDO1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDO2 : HarpCombinator
+    public partial class PulseDO2
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDO2"/> register. This field is constant.
@@ -4256,83 +3154,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDO2"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDO2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDO2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDO2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDO2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDO2 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDO2 register.
     /// </summary>
+    /// <seealso cref="PulseDO2"/>
     [Description("Filters and selects timestamped messages from the PulseDO2 register.")]
-    public partial class TimestampedPulseDO2 : HarpCombinator
+    public partial class TimestampedPulseDO2
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDO2"/> register.
+        /// Represents the address of the <see cref="PulseDO2"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDO2.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDO2.Address, MessageType).Select(PulseDO2.GetTimestampedPayload);
+            return PulseDO2.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duration of the output pulse in milliseconds.
+    /// Represents a register that specifies the duration of the output pulse in milliseconds.
     /// </summary>
     [Description("Specifies the duration of the output pulse in milliseconds.")]
-    public partial class PulseDO3 : HarpCombinator
+    public partial class PulseDO3
     {
         /// <summary>
         /// Represents the address of the <see cref="PulseDO3"/> register. This field is constant.
@@ -4398,83 +3250,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PulseDO3"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PulseDO3"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PulseDO3"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PulseDO3"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PulseDO3"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PulseDO3 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PulseDO3 register.
     /// </summary>
+    /// <seealso cref="PulseDO3"/>
     [Description("Filters and selects timestamped messages from the PulseDO3 register.")]
-    public partial class TimestampedPulseDO3 : HarpCombinator
+    public partial class TimestampedPulseDO3
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PulseDO3"/> register.
+        /// Represents the address of the <see cref="PulseDO3"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PulseDO3.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PulseDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PulseDO3.Address, MessageType).Select(PulseDO3.GetTimestampedPayload);
+            return PulseDO3.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the frequency of the PWM at DO0.
+    /// Represents a register that specifies the frequency of the PWM at DO0.
     /// </summary>
     [Description("Specifies the frequency of the PWM at DO0.")]
-    public partial class PwmFrequencyDO0 : HarpCombinator
+    public partial class PwmFrequencyDO0
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmFrequencyDO0"/> register. This field is constant.
@@ -4540,83 +3346,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmFrequencyDO0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmFrequencyDO0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmFrequencyDO0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmFrequencyDO0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmFrequencyDO0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmFrequencyDO0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmFrequencyDO0 register.
     /// </summary>
+    /// <seealso cref="PwmFrequencyDO0"/>
     [Description("Filters and selects timestamped messages from the PwmFrequencyDO0 register.")]
-    public partial class TimestampedPwmFrequencyDO0 : HarpCombinator
+    public partial class TimestampedPwmFrequencyDO0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmFrequencyDO0"/> register.
+        /// Represents the address of the <see cref="PwmFrequencyDO0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmFrequencyDO0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmFrequencyDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmFrequencyDO0.Address, MessageType).Select(PwmFrequencyDO0.GetTimestampedPayload);
+            return PwmFrequencyDO0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the frequency of the PWM at DO1.
+    /// Represents a register that specifies the frequency of the PWM at DO1.
     /// </summary>
     [Description("Specifies the frequency of the PWM at DO1.")]
-    public partial class PwmFrequencyDO1 : HarpCombinator
+    public partial class PwmFrequencyDO1
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmFrequencyDO1"/> register. This field is constant.
@@ -4682,83 +3442,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmFrequencyDO1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmFrequencyDO1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmFrequencyDO1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmFrequencyDO1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmFrequencyDO1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmFrequencyDO1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmFrequencyDO1 register.
     /// </summary>
+    /// <seealso cref="PwmFrequencyDO1"/>
     [Description("Filters and selects timestamped messages from the PwmFrequencyDO1 register.")]
-    public partial class TimestampedPwmFrequencyDO1 : HarpCombinator
+    public partial class TimestampedPwmFrequencyDO1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmFrequencyDO1"/> register.
+        /// Represents the address of the <see cref="PwmFrequencyDO1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmFrequencyDO1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmFrequencyDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmFrequencyDO1.Address, MessageType).Select(PwmFrequencyDO1.GetTimestampedPayload);
+            return PwmFrequencyDO1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the frequency of the PWM at DO2.
+    /// Represents a register that specifies the frequency of the PWM at DO2.
     /// </summary>
     [Description("Specifies the frequency of the PWM at DO2.")]
-    public partial class PwmFrequencyDO2 : HarpCombinator
+    public partial class PwmFrequencyDO2
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmFrequencyDO2"/> register. This field is constant.
@@ -4824,83 +3538,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmFrequencyDO2"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmFrequencyDO2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmFrequencyDO2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmFrequencyDO2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmFrequencyDO2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmFrequencyDO2 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmFrequencyDO2 register.
     /// </summary>
+    /// <seealso cref="PwmFrequencyDO2"/>
     [Description("Filters and selects timestamped messages from the PwmFrequencyDO2 register.")]
-    public partial class TimestampedPwmFrequencyDO2 : HarpCombinator
+    public partial class TimestampedPwmFrequencyDO2
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmFrequencyDO2"/> register.
+        /// Represents the address of the <see cref="PwmFrequencyDO2"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmFrequencyDO2.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmFrequencyDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmFrequencyDO2.Address, MessageType).Select(PwmFrequencyDO2.GetTimestampedPayload);
+            return PwmFrequencyDO2.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the frequency of the PWM at DO3.
+    /// Represents a register that specifies the frequency of the PWM at DO3.
     /// </summary>
     [Description("Specifies the frequency of the PWM at DO3.")]
-    public partial class PwmFrequencyDO3 : HarpCombinator
+    public partial class PwmFrequencyDO3
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmFrequencyDO3"/> register. This field is constant.
@@ -4966,83 +3634,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmFrequencyDO3"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmFrequencyDO3"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmFrequencyDO3"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmFrequencyDO3"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmFrequencyDO3"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmFrequencyDO3 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmFrequencyDO3 register.
     /// </summary>
+    /// <seealso cref="PwmFrequencyDO3"/>
     [Description("Filters and selects timestamped messages from the PwmFrequencyDO3 register.")]
-    public partial class TimestampedPwmFrequencyDO3 : HarpCombinator
+    public partial class TimestampedPwmFrequencyDO3
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmFrequencyDO3"/> register.
+        /// Represents the address of the <see cref="PwmFrequencyDO3"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmFrequencyDO3.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmFrequencyDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmFrequencyDO3.Address, MessageType).Select(PwmFrequencyDO3.GetTimestampedPayload);
+            return PwmFrequencyDO3.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duty cycle of the PWM at DO0.
+    /// Represents a register that specifies the duty cycle of the PWM at DO0.
     /// </summary>
     [Description("Specifies the duty cycle of the PWM at DO0.")]
-    public partial class PwmDutyCycleDO0 : HarpCombinator
+    public partial class PwmDutyCycleDO0
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmDutyCycleDO0"/> register. This field is constant.
@@ -5108,83 +3730,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmDutyCycleDO0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmDutyCycleDO0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmDutyCycleDO0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmDutyCycleDO0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmDutyCycleDO0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmDutyCycleDO0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmDutyCycleDO0 register.
     /// </summary>
+    /// <seealso cref="PwmDutyCycleDO0"/>
     [Description("Filters and selects timestamped messages from the PwmDutyCycleDO0 register.")]
-    public partial class TimestampedPwmDutyCycleDO0 : HarpCombinator
+    public partial class TimestampedPwmDutyCycleDO0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmDutyCycleDO0"/> register.
+        /// Represents the address of the <see cref="PwmDutyCycleDO0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmDutyCycleDO0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmDutyCycleDO0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmDutyCycleDO0.Address, MessageType).Select(PwmDutyCycleDO0.GetTimestampedPayload);
+            return PwmDutyCycleDO0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duty cycle of the PWM at DO1.
+    /// Represents a register that specifies the duty cycle of the PWM at DO1.
     /// </summary>
     [Description("Specifies the duty cycle of the PWM at DO1.")]
-    public partial class PwmDutyCycleDO1 : HarpCombinator
+    public partial class PwmDutyCycleDO1
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmDutyCycleDO1"/> register. This field is constant.
@@ -5250,83 +3826,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmDutyCycleDO1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmDutyCycleDO1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmDutyCycleDO1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmDutyCycleDO1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmDutyCycleDO1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmDutyCycleDO1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmDutyCycleDO1 register.
     /// </summary>
+    /// <seealso cref="PwmDutyCycleDO1"/>
     [Description("Filters and selects timestamped messages from the PwmDutyCycleDO1 register.")]
-    public partial class TimestampedPwmDutyCycleDO1 : HarpCombinator
+    public partial class TimestampedPwmDutyCycleDO1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmDutyCycleDO1"/> register.
+        /// Represents the address of the <see cref="PwmDutyCycleDO1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmDutyCycleDO1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmDutyCycleDO1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmDutyCycleDO1.Address, MessageType).Select(PwmDutyCycleDO1.GetTimestampedPayload);
+            return PwmDutyCycleDO1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duty cycle of the PWM at DO2.
+    /// Represents a register that specifies the duty cycle of the PWM at DO2.
     /// </summary>
     [Description("Specifies the duty cycle of the PWM at DO2.")]
-    public partial class PwmDutyCycleDO2 : HarpCombinator
+    public partial class PwmDutyCycleDO2
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmDutyCycleDO2"/> register. This field is constant.
@@ -5392,83 +3922,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmDutyCycleDO2"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmDutyCycleDO2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmDutyCycleDO2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmDutyCycleDO2"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmDutyCycleDO2"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmDutyCycleDO2 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmDutyCycleDO2 register.
     /// </summary>
+    /// <seealso cref="PwmDutyCycleDO2"/>
     [Description("Filters and selects timestamped messages from the PwmDutyCycleDO2 register.")]
-    public partial class TimestampedPwmDutyCycleDO2 : HarpCombinator
+    public partial class TimestampedPwmDutyCycleDO2
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmDutyCycleDO2"/> register.
+        /// Represents the address of the <see cref="PwmDutyCycleDO2"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmDutyCycleDO2.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmDutyCycleDO2"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmDutyCycleDO2.Address, MessageType).Select(PwmDutyCycleDO2.GetTimestampedPayload);
+            return PwmDutyCycleDO2.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the duty cycle of the PWM at DO3.
+    /// Represents a register that specifies the duty cycle of the PWM at DO3.
     /// </summary>
     [Description("Specifies the duty cycle of the PWM at DO3.")]
-    public partial class PwmDutyCycleDO3 : HarpCombinator
+    public partial class PwmDutyCycleDO3
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmDutyCycleDO3"/> register. This field is constant.
@@ -5534,83 +4018,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmDutyCycleDO3"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmDutyCycleDO3"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmDutyCycleDO3"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmDutyCycleDO3"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmDutyCycleDO3"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmDutyCycleDO3 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmDutyCycleDO3 register.
     /// </summary>
+    /// <seealso cref="PwmDutyCycleDO3"/>
     [Description("Filters and selects timestamped messages from the PwmDutyCycleDO3 register.")]
-    public partial class TimestampedPwmDutyCycleDO3 : HarpCombinator
+    public partial class TimestampedPwmDutyCycleDO3
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmDutyCycleDO3"/> register.
+        /// Represents the address of the <see cref="PwmDutyCycleDO3"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmDutyCycleDO3.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmDutyCycleDO3"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmDutyCycleDO3.Address, MessageType).Select(PwmDutyCycleDO3.GetTimestampedPayload);
+            return PwmDutyCycleDO3.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that starts the PWM on the selected output lines.
+    /// Represents a register that starts the PWM on the selected output lines.
     /// </summary>
     [Description("Starts the PWM on the selected output lines.")]
-    public partial class PwmStart : HarpCombinator
+    public partial class PwmStart
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmStart"/> register. This field is constant.
@@ -5677,83 +4115,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmStart"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="PwmOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<PwmOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmStart"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="PwmOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmStart"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<PwmOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmStart"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="PwmOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmStart"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<PwmOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmStart register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmStart register.
     /// </summary>
+    /// <seealso cref="PwmStart"/>
     [Description("Filters and selects timestamped messages from the PwmStart register.")]
-    public partial class TimestampedPwmStart : HarpCombinator
+    public partial class TimestampedPwmStart
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmStart"/> register.
+        /// Represents the address of the <see cref="PwmStart"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="PwmOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<PwmOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmStart.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmStart"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<PwmOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmStart.Address, MessageType).Select(PwmStart.GetTimestampedPayload);
+            return PwmStart.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that stops the PWM on the selected output lines.
+    /// Represents a register that stops the PWM on the selected output lines.
     /// </summary>
     [Description("Stops the PWM on the selected output lines.")]
-    public partial class PwmStop : HarpCombinator
+    public partial class PwmStop
     {
         /// <summary>
         /// Represents the address of the <see cref="PwmStop"/> register. This field is constant.
@@ -5819,83 +4211,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PwmStop"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PwmStop"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PwmStop"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PwmStop"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PwmStop"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PwmStop register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PwmStop register.
     /// </summary>
+    /// <seealso cref="PwmStop"/>
     [Description("Filters and selects timestamped messages from the PwmStop register.")]
-    public partial class TimestampedPwmStop : HarpCombinator
+    public partial class TimestampedPwmStop
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PwmStop"/> register.
+        /// Represents the address of the <see cref="PwmStop"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = PwmStop.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PwmStop"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(PwmStop.Address, MessageType).Select(PwmStop.GetTimestampedPayload);
+            return PwmStop.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the state of all RGB LED channels.
+    /// Represents a register that specifies the state of all RGB LED channels.
     /// </summary>
     [Description("Specifies the state of all RGB LED channels.")]
-    public partial class RgbAll : HarpCombinator
+    public partial class RgbAll
     {
         /// <summary>
         /// Represents the address of the <see cref="RgbAll"/> register. This field is constant.
@@ -5987,83 +4333,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="RgbAll"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="RgbAllPayload"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<RgbAllPayload> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="RgbAll"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="RgbAllPayload"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="RgbAll"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<RgbAllPayload> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="RgbAll"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="RgbAllPayload"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="RgbAll"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<RgbAllPayload>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the RgbAll register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// RgbAll register.
     /// </summary>
+    /// <seealso cref="RgbAll"/>
     [Description("Filters and selects timestamped messages from the RgbAll register.")]
-    public partial class TimestampedRgbAll : HarpCombinator
+    public partial class TimestampedRgbAll
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="RgbAll"/> register.
+        /// Represents the address of the <see cref="RgbAll"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="RgbAllPayload"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<RgbAllPayload>> Process(IObservable<HarpMessage> source)
+        public const int Address = RgbAll.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="RgbAll"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<RgbAllPayload> GetPayload(HarpMessage message)
         {
-            return source.Where(RgbAll.Address, MessageType).Select(RgbAll.GetTimestampedPayload);
+            return RgbAll.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the state of the RGB0 LED channels.
+    /// Represents a register that specifies the state of the RGB0 LED channels.
     /// </summary>
     [Description("Specifies the state of the RGB0 LED channels.")]
-    public partial class Rgb0 : HarpCombinator
+    public partial class Rgb0
     {
         /// <summary>
         /// Represents the address of the <see cref="Rgb0"/> register. This field is constant.
@@ -6149,83 +4449,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Rgb0"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="RgbPayload"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<RgbPayload> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Rgb0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="RgbPayload"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Rgb0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<RgbPayload> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Rgb0"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="RgbPayload"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Rgb0"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<RgbPayload>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Rgb0 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Rgb0 register.
     /// </summary>
+    /// <seealso cref="Rgb0"/>
     [Description("Filters and selects timestamped messages from the Rgb0 register.")]
-    public partial class TimestampedRgb0 : HarpCombinator
+    public partial class TimestampedRgb0
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Rgb0"/> register.
+        /// Represents the address of the <see cref="Rgb0"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="RgbPayload"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<RgbPayload>> Process(IObservable<HarpMessage> source)
+        public const int Address = Rgb0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Rgb0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<RgbPayload> GetPayload(HarpMessage message)
         {
-            return source.Where(Rgb0.Address, MessageType).Select(Rgb0.GetTimestampedPayload);
+            return Rgb0.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the state of the RGB1 LED channels.
+    /// Represents a register that specifies the state of the RGB1 LED channels.
     /// </summary>
     [Description("Specifies the state of the RGB1 LED channels.")]
-    public partial class Rgb1 : HarpCombinator
+    public partial class Rgb1
     {
         /// <summary>
         /// Represents the address of the <see cref="Rgb1"/> register. This field is constant.
@@ -6311,83 +4565,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Rgb1"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="RgbPayload"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<RgbPayload> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Rgb1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="RgbPayload"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Rgb1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<RgbPayload> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Rgb1"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="RgbPayload"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Rgb1"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<RgbPayload>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Rgb1 register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Rgb1 register.
     /// </summary>
+    /// <seealso cref="Rgb1"/>
     [Description("Filters and selects timestamped messages from the Rgb1 register.")]
-    public partial class TimestampedRgb1 : HarpCombinator
+    public partial class TimestampedRgb1
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Rgb1"/> register.
+        /// Represents the address of the <see cref="Rgb1"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="RgbPayload"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<RgbPayload>> Process(IObservable<HarpMessage> source)
+        public const int Address = Rgb1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Rgb1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<RgbPayload> GetPayload(HarpMessage message)
         {
-            return source.Where(Rgb1.Address, MessageType).Select(Rgb1.GetTimestampedPayload);
+            return Rgb1.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the configuration of current to drive LED 0.
+    /// Represents a register that specifies the configuration of current to drive LED 0.
     /// </summary>
     [Description("Specifies the configuration of current to drive LED 0.")]
-    public partial class Led0Current : HarpCombinator
+    public partial class Led0Current
     {
         /// <summary>
         /// Represents the address of the <see cref="Led0Current"/> register. This field is constant.
@@ -6453,83 +4661,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Led0Current"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Led0Current"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Led0Current"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Led0Current"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Led0Current"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Led0Current register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Led0Current register.
     /// </summary>
+    /// <seealso cref="Led0Current"/>
     [Description("Filters and selects timestamped messages from the Led0Current register.")]
-    public partial class TimestampedLed0Current : HarpCombinator
+    public partial class TimestampedLed0Current
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Led0Current"/> register.
+        /// Represents the address of the <see cref="Led0Current"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = Led0Current.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Led0Current"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(Led0Current.Address, MessageType).Select(Led0Current.GetTimestampedPayload);
+            return Led0Current.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the configuration of current to drive LED 1.
+    /// Represents a register that specifies the configuration of current to drive LED 1.
     /// </summary>
     [Description("Specifies the configuration of current to drive LED 1.")]
-    public partial class Led1Current : HarpCombinator
+    public partial class Led1Current
     {
         /// <summary>
         /// Represents the address of the <see cref="Led1Current"/> register. This field is constant.
@@ -6595,83 +4757,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Led1Current"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Led1Current"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Led1Current"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Led1Current"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Led1Current"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Led1Current register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Led1Current register.
     /// </summary>
+    /// <seealso cref="Led1Current"/>
     [Description("Filters and selects timestamped messages from the Led1Current register.")]
-    public partial class TimestampedLed1Current : HarpCombinator
+    public partial class TimestampedLed1Current
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Led1Current"/> register.
+        /// Represents the address of the <see cref="Led1Current"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = Led1Current.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Led1Current"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(Led1Current.Address, MessageType).Select(Led1Current.GetTimestampedPayload);
+            return Led1Current.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the configuration of current to drive LED 0.
+    /// Represents a register that specifies the configuration of current to drive LED 0.
     /// </summary>
     [Description("Specifies the configuration of current to drive LED 0.")]
-    public partial class Led0MaxCurrent : HarpCombinator
+    public partial class Led0MaxCurrent
     {
         /// <summary>
         /// Represents the address of the <see cref="Led0MaxCurrent"/> register. This field is constant.
@@ -6737,83 +4853,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Led0MaxCurrent"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Led0MaxCurrent"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Led0MaxCurrent"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Led0MaxCurrent"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Led0MaxCurrent"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Led0MaxCurrent register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Led0MaxCurrent register.
     /// </summary>
+    /// <seealso cref="Led0MaxCurrent"/>
     [Description("Filters and selects timestamped messages from the Led0MaxCurrent register.")]
-    public partial class TimestampedLed0MaxCurrent : HarpCombinator
+    public partial class TimestampedLed0MaxCurrent
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Led0MaxCurrent"/> register.
+        /// Represents the address of the <see cref="Led0MaxCurrent"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = Led0MaxCurrent.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Led0MaxCurrent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(Led0MaxCurrent.Address, MessageType).Select(Led0MaxCurrent.GetTimestampedPayload);
+            return Led0MaxCurrent.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the configuration of current to drive LED 1.
+    /// Represents a register that specifies the configuration of current to drive LED 1.
     /// </summary>
     [Description("Specifies the configuration of current to drive LED 1.")]
-    public partial class Led1MaxCurrent : HarpCombinator
+    public partial class Led1MaxCurrent
     {
         /// <summary>
         /// Represents the address of the <see cref="Led1MaxCurrent"/> register. This field is constant.
@@ -6879,83 +4949,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Led1MaxCurrent"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Led1MaxCurrent"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Led1MaxCurrent"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Led1MaxCurrent"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Led1MaxCurrent"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Led1MaxCurrent register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Led1MaxCurrent register.
     /// </summary>
+    /// <seealso cref="Led1MaxCurrent"/>
     [Description("Filters and selects timestamped messages from the Led1MaxCurrent register.")]
-    public partial class TimestampedLed1MaxCurrent : HarpCombinator
+    public partial class TimestampedLed1MaxCurrent
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Led1MaxCurrent"/> register.
+        /// Represents the address of the <see cref="Led1MaxCurrent"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = Led1MaxCurrent.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Led1MaxCurrent"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(Led1MaxCurrent.Address, MessageType).Select(Led1MaxCurrent.GetTimestampedPayload);
+            return Led1MaxCurrent.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the active events in the device.
+    /// Represents a register that specifies the active events in the device.
     /// </summary>
     [Description("Specifies the active events in the device.")]
-    public partial class EventEnable : HarpCombinator
+    public partial class EventEnable
     {
         /// <summary>
         /// Represents the address of the <see cref="EventEnable"/> register. This field is constant.
@@ -7022,83 +5046,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="EventEnable"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="Events"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<Events> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="EventEnable"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="Events"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="EventEnable"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Events> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="EventEnable"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="Events"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="EventEnable"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<Events>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the EventEnable register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// EventEnable register.
     /// </summary>
+    /// <seealso cref="EventEnable"/>
     [Description("Filters and selects timestamped messages from the EventEnable register.")]
-    public partial class TimestampedEventEnable : HarpCombinator
+    public partial class TimestampedEventEnable
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="EventEnable"/> register.
+        /// Represents the address of the <see cref="EventEnable"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="Events"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<Events>> Process(IObservable<HarpMessage> source)
+        public const int Address = EventEnable.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="EventEnable"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<Events> GetPayload(HarpMessage message)
         {
-            return source.Where(EventEnable.Address, MessageType).Select(EventEnable.GetTimestampedPayload);
+            return EventEnable.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the camera outputs to enable in the device.
+    /// Represents a register that specifies the camera outputs to enable in the device.
     /// </summary>
     [Description("Specifies the camera outputs to enable in the device.")]
-    public partial class StartCameras : HarpCombinator
+    public partial class StartCameras
     {
         /// <summary>
         /// Represents the address of the <see cref="StartCameras"/> register. This field is constant.
@@ -7165,83 +5143,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="StartCameras"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="CameraOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<CameraOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="StartCameras"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="CameraOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="StartCameras"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<CameraOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="StartCameras"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="CameraOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="StartCameras"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<CameraOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the StartCameras register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// StartCameras register.
     /// </summary>
+    /// <seealso cref="StartCameras"/>
     [Description("Filters and selects timestamped messages from the StartCameras register.")]
-    public partial class TimestampedStartCameras : HarpCombinator
+    public partial class TimestampedStartCameras
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="StartCameras"/> register.
+        /// Represents the address of the <see cref="StartCameras"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="CameraOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<CameraOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = StartCameras.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="StartCameras"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<CameraOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(StartCameras.Address, MessageType).Select(StartCameras.GetTimestampedPayload);
+            return StartCameras.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the camera outputs to disable in the device.
+    /// Represents a register that specifies the camera outputs to disable in the device.
     /// </summary>
     [Description("Specifies the camera outputs to disable in the device.")]
-    public partial class StopCameras : HarpCombinator
+    public partial class StopCameras
     {
         /// <summary>
         /// Represents the address of the <see cref="StopCameras"/> register. This field is constant.
@@ -7308,83 +5240,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="StopCameras"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="CameraOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<CameraOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="StopCameras"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="CameraOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="StopCameras"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<CameraOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="StopCameras"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="CameraOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="StopCameras"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<CameraOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the StopCameras register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// StopCameras register.
     /// </summary>
+    /// <seealso cref="StopCameras"/>
     [Description("Filters and selects timestamped messages from the StopCameras register.")]
-    public partial class TimestampedStopCameras : HarpCombinator
+    public partial class TimestampedStopCameras
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="StopCameras"/> register.
+        /// Represents the address of the <see cref="StopCameras"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="CameraOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<CameraOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = StopCameras.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="StopCameras"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<CameraOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(StopCameras.Address, MessageType).Select(StopCameras.GetTimestampedPayload);
+            return StopCameras.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the servo outputs to enable in the device.
+    /// Represents a register that specifies the servo outputs to enable in the device.
     /// </summary>
     [Description("Specifies the servo outputs to enable in the device.")]
-    public partial class EnableServos : HarpCombinator
+    public partial class EnableServos
     {
         /// <summary>
         /// Represents the address of the <see cref="EnableServos"/> register. This field is constant.
@@ -7451,83 +5337,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="EnableServos"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ServoOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ServoOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="EnableServos"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ServoOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="EnableServos"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ServoOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="EnableServos"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ServoOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="EnableServos"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ServoOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the EnableServos register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// EnableServos register.
     /// </summary>
+    /// <seealso cref="EnableServos"/>
     [Description("Filters and selects timestamped messages from the EnableServos register.")]
-    public partial class TimestampedEnableServos : HarpCombinator
+    public partial class TimestampedEnableServos
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="EnableServos"/> register.
+        /// Represents the address of the <see cref="EnableServos"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ServoOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ServoOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = EnableServos.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="EnableServos"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ServoOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(EnableServos.Address, MessageType).Select(EnableServos.GetTimestampedPayload);
+            return EnableServos.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the servo outputs to disable in the device.
+    /// Represents a register that specifies the servo outputs to disable in the device.
     /// </summary>
     [Description("Specifies the servo outputs to disable in the device.")]
-    public partial class DisableServos : HarpCombinator
+    public partial class DisableServos
     {
         /// <summary>
         /// Represents the address of the <see cref="DisableServos"/> register. This field is constant.
@@ -7594,83 +5434,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="DisableServos"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ServoOutputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ServoOutputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="DisableServos"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ServoOutputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="DisableServos"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ServoOutputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="DisableServos"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ServoOutputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="DisableServos"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ServoOutputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the DisableServos register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// DisableServos register.
     /// </summary>
+    /// <seealso cref="DisableServos"/>
     [Description("Filters and selects timestamped messages from the DisableServos register.")]
-    public partial class TimestampedDisableServos : HarpCombinator
+    public partial class TimestampedDisableServos
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="DisableServos"/> register.
+        /// Represents the address of the <see cref="DisableServos"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ServoOutputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ServoOutputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = DisableServos.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="DisableServos"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ServoOutputs> GetPayload(HarpMessage message)
         {
-            return source.Where(DisableServos.Address, MessageType).Select(DisableServos.GetTimestampedPayload);
+            return DisableServos.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the port quadrature counters to enable in the device.
+    /// Represents a register that specifies the port quadrature counters to enable in the device.
     /// </summary>
     [Description("Specifies the port quadrature counters to enable in the device.")]
-    public partial class EnableEncoders : HarpCombinator
+    public partial class EnableEncoders
     {
         /// <summary>
         /// Represents the address of the <see cref="EnableEncoders"/> register. This field is constant.
@@ -7737,83 +5531,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="EnableEncoders"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="EncoderInputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<EncoderInputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="EnableEncoders"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="EncoderInputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="EnableEncoders"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<EncoderInputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="EnableEncoders"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="EncoderInputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="EnableEncoders"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<EncoderInputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the EnableEncoders register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// EnableEncoders register.
     /// </summary>
+    /// <seealso cref="EnableEncoders"/>
     [Description("Filters and selects timestamped messages from the EnableEncoders register.")]
-    public partial class TimestampedEnableEncoders : HarpCombinator
+    public partial class TimestampedEnableEncoders
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="EnableEncoders"/> register.
+        /// Represents the address of the <see cref="EnableEncoders"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="EncoderInputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<EncoderInputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = EnableEncoders.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="EnableEncoders"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<EncoderInputs> GetPayload(HarpMessage message)
         {
-            return source.Where(EnableEncoders.Address, MessageType).Select(EnableEncoders.GetTimestampedPayload);
+            return EnableEncoders.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies that a frame was acquired on camera 0.
+    /// Represents a register that specifies that a frame was acquired on camera 0.
     /// </summary>
     [Description("Specifies that a frame was acquired on camera 0.")]
-    public partial class Camera0Frame : HarpCombinator
+    public partial class Camera0Frame
     {
         /// <summary>
         /// Represents the address of the <see cref="Camera0Frame"/> register. This field is constant.
@@ -7829,14 +5577,6 @@ namespace Harp.Behavior
         /// Represents the length of the <see cref="Camera0Frame"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Camera0Frame"/> class.
-        /// </summary>
-        public Camera0Frame()
-        {
-            MessageType = MessageType.Event;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="Camera0Frame"/> register messages.
@@ -7888,83 +5628,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Camera0Frame"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="FrameAcquired"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<FrameAcquired> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Camera0Frame"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="FrameAcquired"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Camera0Frame"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<FrameAcquired> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Camera0Frame"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="FrameAcquired"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Camera0Frame"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<FrameAcquired>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Camera0Frame register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Camera0Frame register.
     /// </summary>
+    /// <seealso cref="Camera0Frame"/>
     [Description("Filters and selects timestamped messages from the Camera0Frame register.")]
-    public partial class TimestampedCamera0Frame : HarpCombinator
+    public partial class TimestampedCamera0Frame
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Camera0Frame"/> register.
+        /// Represents the address of the <see cref="Camera0Frame"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="FrameAcquired"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<FrameAcquired>> Process(IObservable<HarpMessage> source)
+        public const int Address = Camera0Frame.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Camera0Frame"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<FrameAcquired> GetPayload(HarpMessage message)
         {
-            return source.Where(Camera0Frame.Address, MessageType).Select(Camera0Frame.GetTimestampedPayload);
+            return Camera0Frame.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the trigger frequency for camera 0.
+    /// Represents a register that specifies the trigger frequency for camera 0.
     /// </summary>
     [Description("Specifies the trigger frequency for camera 0.")]
-    public partial class Camera0Frequency : HarpCombinator
+    public partial class Camera0Frequency
     {
         /// <summary>
         /// Represents the address of the <see cref="Camera0Frequency"/> register. This field is constant.
@@ -8030,83 +5724,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Camera0Frequency"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Camera0Frequency"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Camera0Frequency"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Camera0Frequency"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Camera0Frequency"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Camera0Frequency register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Camera0Frequency register.
     /// </summary>
+    /// <seealso cref="Camera0Frequency"/>
     [Description("Filters and selects timestamped messages from the Camera0Frequency register.")]
-    public partial class TimestampedCamera0Frequency : HarpCombinator
+    public partial class TimestampedCamera0Frequency
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Camera0Frequency"/> register.
+        /// Represents the address of the <see cref="Camera0Frequency"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = Camera0Frequency.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Camera0Frequency"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(Camera0Frequency.Address, MessageType).Select(Camera0Frequency.GetTimestampedPayload);
+            return Camera0Frequency.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies that a frame was acquired on camera 1.
+    /// Represents a register that specifies that a frame was acquired on camera 1.
     /// </summary>
     [Description("Specifies that a frame was acquired on camera 1.")]
-    public partial class Camera1Frame : HarpCombinator
+    public partial class Camera1Frame
     {
         /// <summary>
         /// Represents the address of the <see cref="Camera1Frame"/> register. This field is constant.
@@ -8122,14 +5770,6 @@ namespace Harp.Behavior
         /// Represents the length of the <see cref="Camera1Frame"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Camera1Frame"/> class.
-        /// </summary>
-        public Camera1Frame()
-        {
-            MessageType = MessageType.Event;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="Camera1Frame"/> register messages.
@@ -8181,83 +5821,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Camera1Frame"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="FrameAcquired"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<FrameAcquired> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Camera1Frame"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="FrameAcquired"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Camera1Frame"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<FrameAcquired> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Camera1Frame"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="FrameAcquired"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Camera1Frame"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<FrameAcquired>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Camera1Frame register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Camera1Frame register.
     /// </summary>
+    /// <seealso cref="Camera1Frame"/>
     [Description("Filters and selects timestamped messages from the Camera1Frame register.")]
-    public partial class TimestampedCamera1Frame : HarpCombinator
+    public partial class TimestampedCamera1Frame
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Camera1Frame"/> register.
+        /// Represents the address of the <see cref="Camera1Frame"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="FrameAcquired"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<FrameAcquired>> Process(IObservable<HarpMessage> source)
+        public const int Address = Camera1Frame.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Camera1Frame"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<FrameAcquired> GetPayload(HarpMessage message)
         {
-            return source.Where(Camera1Frame.Address, MessageType).Select(Camera1Frame.GetTimestampedPayload);
+            return Camera1Frame.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the trigger frequency for camera 1.
+    /// Represents a register that specifies the trigger frequency for camera 1.
     /// </summary>
     [Description("Specifies the trigger frequency for camera 1.")]
-    public partial class Camera1Frequency : HarpCombinator
+    public partial class Camera1Frequency
     {
         /// <summary>
         /// Represents the address of the <see cref="Camera1Frequency"/> register. This field is constant.
@@ -8323,83 +5917,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="Camera1Frequency"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="Camera1Frequency"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="Camera1Frequency"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="Camera1Frequency"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="Camera1Frequency"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the Camera1Frequency register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// Camera1Frequency register.
     /// </summary>
+    /// <seealso cref="Camera1Frequency"/>
     [Description("Filters and selects timestamped messages from the Camera1Frequency register.")]
-    public partial class TimestampedCamera1Frequency : HarpCombinator
+    public partial class TimestampedCamera1Frequency
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="Camera1Frequency"/> register.
+        /// Represents the address of the <see cref="Camera1Frequency"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = Camera1Frequency.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Camera1Frequency"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(Camera1Frequency.Address, MessageType).Select(Camera1Frequency.GetTimestampedPayload);
+            return Camera1Frequency.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the period of the servo motor in DO2, in microseconds.
+    /// Represents a register that specifies the period of the servo motor in DO2, in microseconds.
     /// </summary>
     [Description("Specifies the period of the servo motor in DO2, in microseconds.")]
-    public partial class ServoMotor2Period : HarpCombinator
+    public partial class ServoMotor2Period
     {
         /// <summary>
         /// Represents the address of the <see cref="ServoMotor2Period"/> register. This field is constant.
@@ -8465,83 +6013,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="ServoMotor2Period"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="ServoMotor2Period"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="ServoMotor2Period"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="ServoMotor2Period"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="ServoMotor2Period"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the ServoMotor2Period register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// ServoMotor2Period register.
     /// </summary>
+    /// <seealso cref="ServoMotor2Period"/>
     [Description("Filters and selects timestamped messages from the ServoMotor2Period register.")]
-    public partial class TimestampedServoMotor2Period : HarpCombinator
+    public partial class TimestampedServoMotor2Period
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="ServoMotor2Period"/> register.
+        /// Represents the address of the <see cref="ServoMotor2Period"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = ServoMotor2Period.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="ServoMotor2Period"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(ServoMotor2Period.Address, MessageType).Select(ServoMotor2Period.GetTimestampedPayload);
+            return ServoMotor2Period.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the pulse of the servo motor in DO2, in microseconds.
+    /// Represents a register that specifies the pulse of the servo motor in DO2, in microseconds.
     /// </summary>
     [Description("Specifies the pulse of the servo motor in DO2, in microseconds.")]
-    public partial class ServoMotor2Pulse : HarpCombinator
+    public partial class ServoMotor2Pulse
     {
         /// <summary>
         /// Represents the address of the <see cref="ServoMotor2Pulse"/> register. This field is constant.
@@ -8607,83 +6109,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="ServoMotor2Pulse"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="ServoMotor2Pulse"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="ServoMotor2Pulse"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="ServoMotor2Pulse"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="ServoMotor2Pulse"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the ServoMotor2Pulse register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// ServoMotor2Pulse register.
     /// </summary>
+    /// <seealso cref="ServoMotor2Pulse"/>
     [Description("Filters and selects timestamped messages from the ServoMotor2Pulse register.")]
-    public partial class TimestampedServoMotor2Pulse : HarpCombinator
+    public partial class TimestampedServoMotor2Pulse
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="ServoMotor2Pulse"/> register.
+        /// Represents the address of the <see cref="ServoMotor2Pulse"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = ServoMotor2Pulse.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="ServoMotor2Pulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(ServoMotor2Pulse.Address, MessageType).Select(ServoMotor2Pulse.GetTimestampedPayload);
+            return ServoMotor2Pulse.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the period of the servo motor in DO3, in microseconds.
+    /// Represents a register that specifies the period of the servo motor in DO3, in microseconds.
     /// </summary>
     [Description("Specifies the period of the servo motor in DO3, in microseconds.")]
-    public partial class ServoMotor3Period : HarpCombinator
+    public partial class ServoMotor3Period
     {
         /// <summary>
         /// Represents the address of the <see cref="ServoMotor3Period"/> register. This field is constant.
@@ -8749,83 +6205,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="ServoMotor3Period"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="ServoMotor3Period"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="ServoMotor3Period"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="ServoMotor3Period"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="ServoMotor3Period"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the ServoMotor3Period register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// ServoMotor3Period register.
     /// </summary>
+    /// <seealso cref="ServoMotor3Period"/>
     [Description("Filters and selects timestamped messages from the ServoMotor3Period register.")]
-    public partial class TimestampedServoMotor3Period : HarpCombinator
+    public partial class TimestampedServoMotor3Period
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="ServoMotor3Period"/> register.
+        /// Represents the address of the <see cref="ServoMotor3Period"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = ServoMotor3Period.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="ServoMotor3Period"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(ServoMotor3Period.Address, MessageType).Select(ServoMotor3Period.GetTimestampedPayload);
+            return ServoMotor3Period.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the pulse of the servo motor in DO3, in microseconds.
+    /// Represents a register that specifies the pulse of the servo motor in DO3, in microseconds.
     /// </summary>
     [Description("Specifies the pulse of the servo motor in DO3, in microseconds.")]
-    public partial class ServoMotor3Pulse : HarpCombinator
+    public partial class ServoMotor3Pulse
     {
         /// <summary>
         /// Represents the address of the <see cref="ServoMotor3Pulse"/> register. This field is constant.
@@ -8891,83 +6301,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="ServoMotor3Pulse"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="ServoMotor3Pulse"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="ServoMotor3Pulse"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="ServoMotor3Pulse"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="ServoMotor3Pulse"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the ServoMotor3Pulse register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// ServoMotor3Pulse register.
     /// </summary>
+    /// <seealso cref="ServoMotor3Pulse"/>
     [Description("Filters and selects timestamped messages from the ServoMotor3Pulse register.")]
-    public partial class TimestampedServoMotor3Pulse : HarpCombinator
+    public partial class TimestampedServoMotor3Pulse
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="ServoMotor3Pulse"/> register.
+        /// Represents the address of the <see cref="ServoMotor3Pulse"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = ServoMotor3Pulse.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="ServoMotor3Pulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(ServoMotor3Pulse.Address, MessageType).Select(ServoMotor3Pulse.GetTimestampedPayload);
+            return ServoMotor3Pulse.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that reset the counter of the specified encoders to zero.
+    /// Represents a register that reset the counter of the specified encoders to zero.
     /// </summary>
     [Description("Reset the counter of the specified encoders to zero.")]
-    public partial class EncoderReset : HarpCombinator
+    public partial class EncoderReset
     {
         /// <summary>
         /// Represents the address of the <see cref="EncoderReset"/> register. This field is constant.
@@ -9034,83 +6398,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="EncoderReset"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="EncoderInputs"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<EncoderInputs> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="EncoderReset"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="EncoderInputs"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="EncoderReset"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<EncoderInputs> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="EncoderReset"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="EncoderInputs"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="EncoderReset"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<EncoderInputs>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the EncoderReset register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// EncoderReset register.
     /// </summary>
+    /// <seealso cref="EncoderReset"/>
     [Description("Filters and selects timestamped messages from the EncoderReset register.")]
-    public partial class TimestampedEncoderReset : HarpCombinator
+    public partial class TimestampedEncoderReset
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="EncoderReset"/> register.
+        /// Represents the address of the <see cref="EncoderReset"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="EncoderInputs"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<EncoderInputs>> Process(IObservable<HarpMessage> source)
+        public const int Address = EncoderReset.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="EncoderReset"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<EncoderInputs> GetPayload(HarpMessage message)
         {
-            return source.Where(EncoderReset.Address, MessageType).Select(EncoderReset.GetTimestampedPayload);
+            return EncoderReset.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that enables the timestamp for serial TX.
+    /// Represents a register that enables the timestamp for serial TX.
     /// </summary>
     [Description("Enables the timestamp for serial TX.")]
-    public partial class EnableSerialTimestamp : HarpCombinator
+    public partial class EnableSerialTimestamp
     {
         /// <summary>
         /// Represents the address of the <see cref="EnableSerialTimestamp"/> register. This field is constant.
@@ -9176,83 +6494,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="EnableSerialTimestamp"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="EnableSerialTimestamp"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="EnableSerialTimestamp"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="EnableSerialTimestamp"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="EnableSerialTimestamp"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the EnableSerialTimestamp register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// EnableSerialTimestamp register.
     /// </summary>
+    /// <seealso cref="EnableSerialTimestamp"/>
     [Description("Filters and selects timestamped messages from the EnableSerialTimestamp register.")]
-    public partial class TimestampedEnableSerialTimestamp : HarpCombinator
+    public partial class TimestampedEnableSerialTimestamp
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="EnableSerialTimestamp"/> register.
+        /// Represents the address of the <see cref="EnableSerialTimestamp"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = EnableSerialTimestamp.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="EnableSerialTimestamp"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(EnableSerialTimestamp.Address, MessageType).Select(EnableSerialTimestamp.GetTimestampedPayload);
+            return EnableSerialTimestamp.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the digital output to mimic the Port 0 IR state.
+    /// Represents a register that specifies the digital output to mimic the Port 0 IR state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 0 IR state.")]
-    public partial class MimicPort0IR : HarpCombinator
+    public partial class MimicPort0IR
     {
         /// <summary>
         /// Represents the address of the <see cref="MimicPort0IR"/> register. This field is constant.
@@ -9319,83 +6591,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="MimicPort0IR"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="MimicPort0IR"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="MimicPort0IR"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="MimicPort0IR"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="MimicPort0IR"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the MimicPort0IR register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// MimicPort0IR register.
     /// </summary>
+    /// <seealso cref="MimicPort0IR"/>
     [Description("Filters and selects timestamped messages from the MimicPort0IR register.")]
-    public partial class TimestampedMimicPort0IR : HarpCombinator
+    public partial class TimestampedMimicPort0IR
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="MimicPort0IR"/> register.
+        /// Represents the address of the <see cref="MimicPort0IR"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        public const int Address = MimicPort0IR.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="MimicPort0IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetPayload(HarpMessage message)
         {
-            return source.Where(MimicPort0IR.Address, MessageType).Select(MimicPort0IR.GetTimestampedPayload);
+            return MimicPort0IR.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the digital output to mimic the Port 1 IR state.
+    /// Represents a register that specifies the digital output to mimic the Port 1 IR state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 1 IR state.")]
-    public partial class MimicPort1IR : HarpCombinator
+    public partial class MimicPort1IR
     {
         /// <summary>
         /// Represents the address of the <see cref="MimicPort1IR"/> register. This field is constant.
@@ -9462,83 +6688,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="MimicPort1IR"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="MimicPort1IR"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="MimicPort1IR"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="MimicPort1IR"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="MimicPort1IR"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the MimicPort1IR register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// MimicPort1IR register.
     /// </summary>
+    /// <seealso cref="MimicPort1IR"/>
     [Description("Filters and selects timestamped messages from the MimicPort1IR register.")]
-    public partial class TimestampedMimicPort1IR : HarpCombinator
+    public partial class TimestampedMimicPort1IR
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="MimicPort1IR"/> register.
+        /// Represents the address of the <see cref="MimicPort1IR"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        public const int Address = MimicPort1IR.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="MimicPort1IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetPayload(HarpMessage message)
         {
-            return source.Where(MimicPort1IR.Address, MessageType).Select(MimicPort1IR.GetTimestampedPayload);
+            return MimicPort1IR.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the digital output to mimic the Port 2 IR state.
+    /// Represents a register that specifies the digital output to mimic the Port 2 IR state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 2 IR state.")]
-    public partial class MimicPort2IR : HarpCombinator
+    public partial class MimicPort2IR
     {
         /// <summary>
         /// Represents the address of the <see cref="MimicPort2IR"/> register. This field is constant.
@@ -9605,83 +6785,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="MimicPort2IR"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="MimicPort2IR"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="MimicPort2IR"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="MimicPort2IR"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="MimicPort2IR"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the MimicPort2IR register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// MimicPort2IR register.
     /// </summary>
+    /// <seealso cref="MimicPort2IR"/>
     [Description("Filters and selects timestamped messages from the MimicPort2IR register.")]
-    public partial class TimestampedMimicPort2IR : HarpCombinator
+    public partial class TimestampedMimicPort2IR
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="MimicPort2IR"/> register.
+        /// Represents the address of the <see cref="MimicPort2IR"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        public const int Address = MimicPort2IR.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="MimicPort2IR"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetPayload(HarpMessage message)
         {
-            return source.Where(MimicPort2IR.Address, MessageType).Select(MimicPort2IR.GetTimestampedPayload);
+            return MimicPort2IR.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the digital output to mimic the Port 0 valve state.
+    /// Represents a register that specifies the digital output to mimic the Port 0 valve state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 0 valve state.")]
-    public partial class MimicPort0Valve : HarpCombinator
+    public partial class MimicPort0Valve
     {
         /// <summary>
         /// Represents the address of the <see cref="MimicPort0Valve"/> register. This field is constant.
@@ -9748,83 +6882,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="MimicPort0Valve"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="MimicPort0Valve"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="MimicPort0Valve"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="MimicPort0Valve"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="MimicPort0Valve"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the MimicPort0Valve register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// MimicPort0Valve register.
     /// </summary>
+    /// <seealso cref="MimicPort0Valve"/>
     [Description("Filters and selects timestamped messages from the MimicPort0Valve register.")]
-    public partial class TimestampedMimicPort0Valve : HarpCombinator
+    public partial class TimestampedMimicPort0Valve
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="MimicPort0Valve"/> register.
+        /// Represents the address of the <see cref="MimicPort0Valve"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        public const int Address = MimicPort0Valve.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="MimicPort0Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetPayload(HarpMessage message)
         {
-            return source.Where(MimicPort0Valve.Address, MessageType).Select(MimicPort0Valve.GetTimestampedPayload);
+            return MimicPort0Valve.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the digital output to mimic the Port 1 valve state.
+    /// Represents a register that specifies the digital output to mimic the Port 1 valve state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 1 valve state.")]
-    public partial class MimicPort1Valve : HarpCombinator
+    public partial class MimicPort1Valve
     {
         /// <summary>
         /// Represents the address of the <see cref="MimicPort1Valve"/> register. This field is constant.
@@ -9891,83 +6979,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="MimicPort1Valve"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="MimicPort1Valve"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="MimicPort1Valve"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="MimicPort1Valve"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="MimicPort1Valve"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the MimicPort1Valve register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// MimicPort1Valve register.
     /// </summary>
+    /// <seealso cref="MimicPort1Valve"/>
     [Description("Filters and selects timestamped messages from the MimicPort1Valve register.")]
-    public partial class TimestampedMimicPort1Valve : HarpCombinator
+    public partial class TimestampedMimicPort1Valve
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="MimicPort1Valve"/> register.
+        /// Represents the address of the <see cref="MimicPort1Valve"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        public const int Address = MimicPort1Valve.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="MimicPort1Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetPayload(HarpMessage message)
         {
-            return source.Where(MimicPort1Valve.Address, MessageType).Select(MimicPort1Valve.GetTimestampedPayload);
+            return MimicPort1Valve.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the digital output to mimic the Port 2 valve state.
+    /// Represents a register that specifies the digital output to mimic the Port 2 valve state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 2 valve state.")]
-    public partial class MimicPort2Valve : HarpCombinator
+    public partial class MimicPort2Valve
     {
         /// <summary>
         /// Represents the address of the <see cref="MimicPort2Valve"/> register. This field is constant.
@@ -10034,83 +7076,37 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="MimicPort2Valve"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<MimicOutput> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="MimicPort2Valve"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="MimicOutput"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="MimicPort2Valve"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<MimicOutput> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="MimicPort2Valve"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="MimicPort2Valve"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<MimicOutput>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the MimicPort2Valve register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// MimicPort2Valve register.
     /// </summary>
+    /// <seealso cref="MimicPort2Valve"/>
     [Description("Filters and selects timestamped messages from the MimicPort2Valve register.")]
-    public partial class TimestampedMimicPort2Valve : HarpCombinator
+    public partial class TimestampedMimicPort2Valve
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="MimicPort2Valve"/> register.
+        /// Represents the address of the <see cref="MimicPort2Valve"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="MimicOutput"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<MimicOutput>> Process(IObservable<HarpMessage> source)
+        public const int Address = MimicPort2Valve.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="MimicPort2Valve"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<MimicOutput> GetPayload(HarpMessage message)
         {
-            return source.Where(MimicPort2Valve.Address, MessageType).Select(MimicPort2Valve.GetTimestampedPayload);
+            return MimicPort2Valve.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the low pass filter time value for poke inputs, in ms.
+    /// Represents a register that specifies the low pass filter time value for poke inputs, in ms.
     /// </summary>
     [Description("Specifies the low pass filter time value for poke inputs, in ms.")]
-    public partial class PokeInputFilter : HarpCombinator
+    public partial class PokeInputFilter
     {
         /// <summary>
         /// Represents the address of the <see cref="PokeInputFilter"/> register. This field is constant.
@@ -10176,75 +7172,29 @@ namespace Harp.Behavior
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="PokeInputFilter"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="PokeInputFilter"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="PokeInputFilter"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="PokeInputFilter"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="PokeInputFilter"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the PokeInputFilter register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// PokeInputFilter register.
     /// </summary>
+    /// <seealso cref="PokeInputFilter"/>
     [Description("Filters and selects timestamped messages from the PokeInputFilter register.")]
-    public partial class TimestampedPokeInputFilter : HarpCombinator
+    public partial class TimestampedPokeInputFilter
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="PokeInputFilter"/> register.
+        /// Represents the address of the <see cref="PokeInputFilter"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = PokeInputFilter.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="PokeInputFilter"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(PokeInputFilter.Address, MessageType).Select(PokeInputFilter.GetTimestampedPayload);
+            return PokeInputFilter.GetTimestampedPayload(message);
         }
     }
 
@@ -10252,6 +7202,7 @@ namespace Harp.Behavior
     /// Represents an operator which creates standard message payloads for the
     /// Behavior device.
     /// </summary>
+    /// <seealso cref="CreatePortDigitalInputPayload"/>
     /// <seealso cref="CreateOutputSetPayload"/>
     /// <seealso cref="CreateOutputClearPayload"/>
     /// <seealso cref="CreateOutputTogglePayload"/>
@@ -10261,6 +7212,8 @@ namespace Harp.Behavior
     /// <seealso cref="CreatePortDIOTogglePayload"/>
     /// <seealso cref="CreatePortDIOStatePayload"/>
     /// <seealso cref="CreatePortDIODirectionPayload"/>
+    /// <seealso cref="CreatePortDIOStateEventPayload"/>
+    /// <seealso cref="CreateAnalogDataPayload"/>
     /// <seealso cref="CreateOutputPulseEnablePayload"/>
     /// <seealso cref="CreatePulseDOPort0Payload"/>
     /// <seealso cref="CreatePulseDOPort1Payload"/>
@@ -10299,7 +7252,9 @@ namespace Harp.Behavior
     /// <seealso cref="CreateEnableServosPayload"/>
     /// <seealso cref="CreateDisableServosPayload"/>
     /// <seealso cref="CreateEnableEncodersPayload"/>
+    /// <seealso cref="CreateCamera0FramePayload"/>
     /// <seealso cref="CreateCamera0FrequencyPayload"/>
+    /// <seealso cref="CreateCamera1FramePayload"/>
     /// <seealso cref="CreateCamera1FrequencyPayload"/>
     /// <seealso cref="CreateServoMotor2PeriodPayload"/>
     /// <seealso cref="CreateServoMotor2PulsePayload"/>
@@ -10314,6 +7269,7 @@ namespace Harp.Behavior
     /// <seealso cref="CreateMimicPort1ValvePayload"/>
     /// <seealso cref="CreateMimicPort2ValvePayload"/>
     /// <seealso cref="CreatePokeInputFilterPayload"/>
+    [XmlInclude(typeof(CreatePortDigitalInputPayload))]
     [XmlInclude(typeof(CreateOutputSetPayload))]
     [XmlInclude(typeof(CreateOutputClearPayload))]
     [XmlInclude(typeof(CreateOutputTogglePayload))]
@@ -10323,6 +7279,8 @@ namespace Harp.Behavior
     [XmlInclude(typeof(CreatePortDIOTogglePayload))]
     [XmlInclude(typeof(CreatePortDIOStatePayload))]
     [XmlInclude(typeof(CreatePortDIODirectionPayload))]
+    [XmlInclude(typeof(CreatePortDIOStateEventPayload))]
+    [XmlInclude(typeof(CreateAnalogDataPayload))]
     [XmlInclude(typeof(CreateOutputPulseEnablePayload))]
     [XmlInclude(typeof(CreatePulseDOPort0Payload))]
     [XmlInclude(typeof(CreatePulseDOPort1Payload))]
@@ -10361,7 +7319,9 @@ namespace Harp.Behavior
     [XmlInclude(typeof(CreateEnableServosPayload))]
     [XmlInclude(typeof(CreateDisableServosPayload))]
     [XmlInclude(typeof(CreateEnableEncodersPayload))]
+    [XmlInclude(typeof(CreateCamera0FramePayload))]
     [XmlInclude(typeof(CreateCamera0FrequencyPayload))]
+    [XmlInclude(typeof(CreateCamera1FramePayload))]
     [XmlInclude(typeof(CreateCamera1FrequencyPayload))]
     [XmlInclude(typeof(CreateServoMotor2PeriodPayload))]
     [XmlInclude(typeof(CreateServoMotor2PulsePayload))]
@@ -10384,10 +7344,58 @@ namespace Harp.Behavior
         /// </summary>
         public CreateMessage()
         {
-            Payload = new CreateOutputSetPayload();
+            Payload = new CreatePortDigitalInputPayload();
         }
 
         string INamedElement.Name => $"{nameof(Behavior)}.{GetElementDisplayName(Payload)}";
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that reflects the state of DI digital lines of each Port.
+    /// </summary>
+    [DisplayName("PortDigitalInputPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that reflects the state of DI digital lines of each Port.")]
+    public partial class CreatePortDigitalInputPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that reflects the state of DI digital lines of each Port.
+        /// </summary>
+        [Description("The value that reflects the state of DI digital lines of each Port.")]
+        public DigitalInputs Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that reflects the state of DI digital lines of each Port.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that reflects the state of DI digital lines of each Port.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDigitalInput.FromPayload(MessageType, Value));
+        }
     }
 
     /// <summary>
@@ -10819,6 +7827,114 @@ namespace Harp.Behavior
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
             return source.Select(_ => PortDIODirection.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the state of the port DIO lines on a line change.
+    /// </summary>
+    [DisplayName("PortDIOStateEventPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the state of the port DIO lines on a line change.")]
+    public partial class CreatePortDIOStateEventPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the state of the port DIO lines on a line change.
+        /// </summary>
+        [Description("The value that specifies the state of the port DIO lines on a line change.")]
+        public PortDigitalIOS Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the state of the port DIO lines on a line change.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the state of the port DIO lines on a line change.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => PortDIOStateEvent.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that voltage at the ADC input and encoder value on Port 2.
+    /// </summary>
+    [DisplayName("AnalogDataPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that voltage at the ADC input and encoder value on Port 2.")]
+    public partial class CreateAnalogDataPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets a value that the voltage at the output of the ADC.
+        /// </summary>
+        [Description("The voltage at the output of the ADC")]
+        public short AnalogInput { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the quadrature counter value on Port 2.
+        /// </summary>
+        [Description("The quadrature counter value on Port 2")]
+        public short Encoder { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that voltage at the ADC input and encoder value on Port 2.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that voltage at the ADC input and encoder value on Port 2.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ =>
+            {
+                AnalogDataPayload value;
+                value.AnalogInput = AnalogInput;
+                value.Encoder = Encoder;
+                return AnalogData.FromPayload(MessageType, value);
+            });
         }
     }
 
@@ -12780,6 +9896,54 @@ namespace Harp.Behavior
 
     /// <summary>
     /// Represents an operator that creates a sequence of message payloads
+    /// that specifies that a frame was acquired on camera 0.
+    /// </summary>
+    [DisplayName("Camera0FramePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies that a frame was acquired on camera 0.")]
+    public partial class CreateCamera0FramePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies that a frame was acquired on camera 0.
+        /// </summary>
+        [Description("The value that specifies that a frame was acquired on camera 0.")]
+        public FrameAcquired Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies that a frame was acquired on camera 0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies that a frame was acquired on camera 0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Camera0Frame.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
     /// that specifies the trigger frequency for camera 0.
     /// </summary>
     [DisplayName("Camera0FrequencyPayload")]
@@ -12825,6 +9989,54 @@ namespace Harp.Behavior
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
             return source.Select(_ => Camera0Frequency.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies that a frame was acquired on camera 1.
+    /// </summary>
+    [DisplayName("Camera1FramePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies that a frame was acquired on camera 1.")]
+    public partial class CreateCamera1FramePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies that a frame was acquired on camera 1.
+        /// </summary>
+        [Description("The value that specifies that a frame was acquired on camera 1.")]
+        public FrameAcquired Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies that a frame was acquired on camera 1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies that a frame was acquired on camera 1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Camera1Frame.FromPayload(MessageType, Value));
         }
     }
 

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -4,6 +4,8 @@
     <Title>Harp.Behavior</Title>
     <Authors></Authors>
     <Copyright>Copyright © harp-tech 2023</Copyright>
+    <IncludeSymbols Condition="'$(Configuration)'=='Release'">true</IncludeSymbols>
+    <SymbolPackageFormat Condition="'$(Configuration)'=='Release'">snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <Description>Bonsai Library containing interfaces for data acquisition and control of Harp Behavior devices.</Description>
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Harp.Behavior</Title>
+    <Authors></Authors>
+    <Copyright>Copyright © harp-tech 2023</Copyright>
+    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+    <Description>Bonsai Library containing interfaces for data acquisition and control of Harp.Behavior devices.</Description>
+    <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
+    <PackageTags>Harp Harp.Behavior Bonsai Rx</PackageTags>
+    <PackageProjectUrl></PackageProjectUrl>
+    <PackageLicenseExpression></PackageLicenseExpression>
+    <PackageIcon></PackageIcon>
+    <PackageOutputPath></PackageOutputPath>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionSuffix>build032301</VersionSuffix>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build032301" GeneratePathProperty="true" />
+  </ItemGroup>
+
+</Project>

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -7,19 +7,19 @@
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <Description>Bonsai Library containing interfaces for data acquisition and control of Harp.Behavior devices.</Description>
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
-    <PackageTags>Harp Harp.Behavior Bonsai Rx</PackageTags>
+    <PackageTags>Harp Behavior Bonsai Rx</PackageTags>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageIcon></PackageIcon>
     <PackageOutputPath></PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build032301</VersionSuffix>
+    <VersionSuffix>build032701</VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build032301" GeneratePathProperty="true" />
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build032701" />
   </ItemGroup>
 
 </Project>

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -5,7 +5,7 @@
     <Authors></Authors>
     <Copyright>Copyright © harp-tech 2023</Copyright>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <Description>Bonsai Library containing interfaces for data acquisition and control of Harp.Behavior devices.</Description>
+    <Description>Bonsai Library containing interfaces for data acquisition and control of Harp Behavior devices.</Description>
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
     <PackageTags>Harp Behavior Bonsai Rx</PackageTags>
     <PackageProjectUrl></PackageProjectUrl>

--- a/Interface/Harp.Behavior/Properties/AssemblyInfo.cs
+++ b/Interface/Harp.Behavior/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Harp.Behavior", "beh")]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Daq")]

--- a/Interface/Harp.Behavior/Properties/launchSettings.json
+++ b/Interface/Harp.Behavior/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir)."
+    }
+  }
+}

--- a/Interface/LICENSE
+++ b/Interface/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2023 harp-tech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/device.yml
+++ b/device.yml
@@ -1,0 +1,501 @@
+%YAML 1.1
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/harp-tech/reflex-generator/main/schema/device.json
+device: Behavior
+whoAmI: 1216
+firmwareVersion: "3.0"
+hardwareTargets: "2.0"
+registers:
+  PortDigitalInput:
+    address: 32
+    access: Event
+    type: U8
+    maskType: DigitalInputs
+    description: Reflects the state of DI digital lines of each Port
+  Reserved0: &reserved
+    address: 33
+    type: U8
+    access: Read
+    description: Reserved for future use
+    visibility: private
+  OutputSet: &output
+    address: 34
+    type: U16
+    access: Write
+    maskType: DigitalOutputs
+    description: Set the specified digital output lines.
+  OutputClear:
+    <<: *output
+    address: 35
+    description: Clear the specified digital output lines
+  OutputToggle:
+    <<: *output
+    address: 36
+    description: Toggle the specified digital output lines
+  OutputState:
+    <<: *output
+    address: 37
+    description: Write the state of all digital output lines
+  PortDIOSet: &portDIO
+    address: 38
+    type: U8
+    access: Write
+    maskType: PortDigitalIOS
+    description: Set the specified port DIO lines
+  PortDIOClear:
+    <<: *portDIO
+    address: 39
+    description: Clear the specified port DIO lines
+  PortDIOToggle:
+    <<: *portDIO
+    address: 40
+    description: Toggle the specified port DIO lines
+  PortDIOState:
+    <<: *portDIO
+    address: 41
+    description: Write the state of all port DIO lines
+  PortDIODirection:
+    <<: *portDIO
+    address: 42
+    description: Specifies which of the port DIO lines are outputs
+  PortDIOStateEvent:
+    <<: *portDIO
+    address: 43
+    access: Event
+    description: Specifies the state of the port DIO lines on a line change
+  AnalogData:
+    address: 44
+    type: S16
+    length: 2
+    access: Event
+    description: Voltage at the ADC input and encoder value on Port 2
+    payloadSpec:
+      AnalogInput:
+        offset: 0
+        description: The voltage at the output of the ADC
+      Encoder:
+        offset: 1
+        description: The quadrature counter value on Port 2
+  OutputPulseEnable:
+    <<: *output
+    address: 45
+    description: Enables the pulse function for the specified output lines
+  PulseDOPort0: &pulseDO
+    address: 46
+    type: U16
+    access: Write
+    minValue: 1
+    description: Specifies the duration of the output pulse in milliseconds.
+  PulseDOPort1:
+    <<: *pulseDO
+    address: 47
+  PulseDOPort2:
+    <<: *pulseDO
+    address: 48
+  PulseSupplyPort0:
+    <<: *pulseDO
+    address: 49
+  PulseSupplyPort1:
+    <<: *pulseDO
+    address: 50
+  PulseSupplyPort2:
+    <<: *pulseDO
+    address: 51
+  PulseLed0:
+    <<: *pulseDO
+    address: 52
+  PulseLed1:
+    <<: *pulseDO
+    address: 53
+  PulseRgb0:
+    <<: *pulseDO
+    address: 54
+  PulseRgb1:
+    <<: *pulseDO
+    address: 55
+  PulseDO0:
+    <<: *pulseDO
+    address: 56
+  PulseDO1:
+    <<: *pulseDO
+    address: 57
+  PulseDO2:
+    <<: *pulseDO
+    address: 58
+  PulseDO3:
+    <<: *pulseDO
+    address: 59
+  PwmFrequencyDO0: &pwmFreq
+    address: 60
+    type: U16
+    access: Write
+    minValue: 1
+    description: Specifies the frequency of the PWM at DO0.
+  PwmFrequencyDO1:
+    <<: *pwmFreq
+    address: 61
+    description: Specifies the frequency of the PWM at DO1.
+  PwmFrequencyDO2:
+    <<: *pwmFreq
+    address: 62
+    description: Specifies the frequency of the PWM at DO2.
+  PwmFrequencyDO3:
+    <<: *pwmFreq
+    address: 63
+    description: Specifies the frequency of the PWM at DO3.
+  PwmDutyCycleDO0: &pwmDutyCycle
+    address: 64
+    type: U8
+    access: Write
+    minValue: 1
+    maxValue: 99
+    description: Specifies the duty cycle of the PWM at DO0.
+  PwmDutyCycleDO1:
+    <<: *pwmDutyCycle
+    address: 65
+    description: Specifies the duty cycle of the PWM at DO1.
+  PwmDutyCycleDO2:
+    <<: *pwmDutyCycle
+    address: 66
+    description: Specifies the duty cycle of the PWM at DO2.
+  PwmDutyCycleDO3:
+    <<: *pwmDutyCycle
+    address: 67
+    description: Specifies the duty cycle of the PWM at DO3.
+  PwmStart: &pwmStartStop
+    address: 68
+    type: U8
+    access: Write
+    maskType: PwmOutputs
+    description: Starts the PWM on the selected output lines.
+  PwmStop:
+    <<: *pwmDutyCycle 
+    address: 69
+    description: Stops the PWM on the selected output lines.
+  RgbAll:
+    address: 70
+    type: &rgbType U8
+    length: 6
+    access: &rgbAccess Write
+    description: Specifies the state of all RGB LED channels.
+    payloadSpec:
+      Green0:
+        offset: 0
+        description: The intensity of the green channel in the RGB0 LED.
+      Red0:
+        offset: 1
+        description: The intensity of the red channel in the RGB0 LED.
+      Blue0:
+        offset: 2
+        description: The intensity of the blue channel in the RGB0 LED.
+      Green1:
+        offset: 3
+        description: The intensity of the green channel in the RGB1 LED.
+      Red1:
+        offset: 4
+        description: The intensity of the red channel in the RGB1 LED.
+      Blue1:
+        offset: 5
+        description: The intensity of the blue channel in the RGB1 LED.
+  Rgb0: &rgbRegister
+    address: 71
+    type: *rgbType
+    length: 3
+    access: *rgbAccess
+    description: Specifies the state of the RGB0 LED channels.
+    interfaceType: RgbPayload
+    payloadSpec:
+      Green:
+        offset: 0
+        description: The intensity of the green channel in the RGB LED.
+      Red:
+        offset: 1
+        description: The intensity of the red channel in the RGB LED.
+      Blue:
+        offset: 2
+        description: The intensity of the blue channel in the RGB LED.
+  Rgb1:
+    <<: *rgbRegister
+    address: 72
+    description: Specifies the state of the RGB1 LED channels.
+  Led0Current: &ledCurrent
+    address: 73
+    type: U8
+    access: Write
+    minValue: 2
+    maxValue: 100
+    description: Specifies the configuration of current to drive LED 0.
+  Led1Current:
+    <<: *ledCurrent
+    address: 74
+    description: Specifies the configuration of current to drive LED 1.
+  Led0MaxCurrent: &ledMaxCurrent
+    address: 75
+    type: U8
+    access: Write
+    minValue: 5
+    maxValue: 100
+    description: Specifies the configuration of current to drive LED 0.
+  Led1MaxCurrent:
+    <<: *ledMaxCurrent
+    address: 76
+    description: Specifies the configuration of current to drive LED 1.
+  EventEnable:
+    address: 77
+    type: U8
+    access: Write
+    maskType: Events
+    description: Specifies the active events in the device.
+  StartCameras: &cameraControl
+    address: 78
+    type: U8
+    access: Write
+    maskType: CameraOutputs
+    description: Specifies the camera outputs to enable in the device.
+  StopCameras:
+    <<: *cameraControl
+    address: 79
+    description: Specifies the camera outputs to disable in the device.
+  EnableServos: &servoControl
+    address: 80
+    type: U8
+    access: Write
+    maskType: ServoOutputs
+    description: Specifies the servo outputs to enable in the device.
+  DisableServos:
+    <<: *servoControl
+    address: 81
+    description: Specifies the servo outputs to disable in the device.
+  EnableEncoders:
+    address: 82
+    type: U8
+    access: Write
+    maskType: EncoderInputs
+    description: Specifies the port quadrature counters to enable in the device.
+  Reserved1:
+    <<: *reserved
+    address: 83
+  Reserved2:
+    <<: *reserved
+    address: 84
+  Reserved3:
+    <<: *reserved
+    address: 85
+  Reserved4:
+    <<: *reserved
+    address: 86
+  Reserved5:
+    <<: *reserved
+    address: 87
+  Reserved6:
+    <<: *reserved
+    address: 88
+  Reserved7:
+    <<: *reserved
+    address: 89
+  Reserved8:
+    <<: *reserved
+    address: 90
+  Reserved9:
+    <<: *reserved
+    address: 91
+  Camera0Frame: &frameAcquired
+    address: 92
+    type: U8
+    access: Event
+    maskType: FrameAcquired
+    description: Specifies that a frame was acquired on camera 0.
+  Camera0Frequency: &cameraFreq
+    address: 93
+    type: U16
+    access: Write
+    minValue: 1
+    maxValue: 600
+    description: Specifies the trigger frequency for camera 0.
+  Camera1Frame:
+    <<: *frameAcquired
+    address: 94
+    description: Specifies that a frame was acquired on camera 1.
+  Camera1Frequency:
+    <<: *cameraFreq
+    address: 95
+    description: Specifies the trigger frequency for camera 1.
+  Reserved10:
+    <<: *reserved
+    address: 96
+  Reserved11:
+    <<: *reserved
+    address: 97
+  Reserved12:
+    <<: *reserved
+    address: 98
+  Reserved13:
+    <<: *reserved
+    address: 99
+  ServoMotor2Period: &servoPeriod
+    address: 100
+    type: U16
+    access: Write
+    description: Specifies the period of the servo motor in DO2, in microseconds.
+  ServoMotor2Pulse: &servoPulse
+    address: 101
+    type: U16
+    access: Write
+    description: Specifies the pulse of the servo motor in DO2, in microseconds.
+  ServoMotor3Period:
+    <<: *servoPeriod
+    address: 102
+    description: Specifies the period of the servo motor in DO3, in microseconds.
+  ServoMotor3Pulse:
+    <<: *servoPulse
+    address: 103
+    description: Specifies the pulse of the servo motor in DO3, in microseconds.
+  Reserved14:
+    <<: *reserved
+    address: 104
+  Reserved15:
+    <<: *reserved
+    address: 105
+  Reserved16:
+    <<: *reserved
+    address: 106
+  Reserved17:
+    <<: *reserved
+    address: 107
+  EncoderReset:
+    address: 108
+    type: U8
+    access: Write
+    maskType: EncoderInputs
+    description: Reset the counter of the specified encoders to zero.
+  Reserved18:
+    <<: *reserved
+    address: 109
+  EnableSerialTimestamp:
+    address: 110
+    type: U8
+    access: Write
+    description: Enables the timestamp for serial TX.
+  MimicPort0IR: &mimic
+    address: 111
+    type: U8
+    access: Write
+    maskType: MimicOutput
+    description: Specifies the digital output to mimic the Port 0 IR state.
+  MimicPort1IR:
+    <<: *mimic
+    address: 112
+    description: Specifies the digital output to mimic the Port 1 IR state.
+  MimicPort2IR:
+    <<: *mimic
+    address: 113
+    description: Specifies the digital output to mimic the Port 2 IR state.
+  Reserved20:
+    <<: *reserved
+    address: 114
+  Reserved21:
+    <<: *reserved
+    address: 115
+  Reserved22:
+    <<: *reserved
+    address: 116
+  MimicPort0Valve:
+    <<: *mimic
+    address: 117
+    description: Specifies the digital output to mimic the Port 0 valve state.
+  MimicPort1Valve:
+    <<: *mimic
+    address: 118
+    description: Specifies the digital output to mimic the Port 1 valve state.
+  MimicPort2Valve:
+    <<: *mimic
+    address: 119
+    description: Specifies the digital output to mimic the Port 2 valve state.
+  Reserved23:
+    <<: *reserved
+    address: 120
+  Reserved24:
+    <<: *reserved
+    address: 121
+  PokeInputFilter:
+    address: 122
+    type: U8
+    access: Write
+    description: Specifies the low pass filter time value for poke inputs, in ms.
+bitMasks:
+  DigitalInputs:
+    description: Specifies the state of port digital input lines.
+    bits:
+      DI0: 0x1
+      DI1: 0x2
+      DI2: 0x4
+      DI3: 0x8
+  DigitalOutputs:
+    description: Specifies the state of port digital output lines.
+    bits:
+      DOPort0: 0x1
+      DOPort1: 0x2
+      DOPort2: 0x4
+      SupplyPort0: 0x8
+      SupplyPort1: 0x10
+      SupplyPort2: 0x20
+      Led0: 0x40
+      Led1: 0x80
+      Rgb0: 0x100
+      Rgb1: 0x200
+      DO0: 0x400
+      DO1: 0x800
+      DO2: 0x1000
+      DO3: 0x2000
+  PortDigitalIOS:
+    description: Specifies the state of the port DIO lines.
+    bits:
+      DIO0: 0x1
+      DIO1: 0x2
+      DIO2: 0x4
+  PwmOutputs:
+    description: Specifies the state of PWM output lines.
+    bits:
+      PwmDO0: 0x1
+      PwmDO1: 0x2
+      PwmDO2: 0x4
+      PwmDO3: 0x8
+  Events:
+    description: Specifies the active events in the device.
+    bits:
+      PortDI: 0x1
+      PortDIO: 0x2
+      AnalogData: 0x4
+      Camera0: 0x8
+      Camera1: 0x10
+  CameraOutputs:
+    description: Specifies camera output enable bits.
+    bits:
+      CameraOutput0: 0x1
+      CameraOutput1: 0x2
+  ServoOutputs:
+    description: Specifies servo output enable bits.
+    bits:
+      ServoOutput2: 0x4
+      ServoOutput3: 0x8
+  EncoderInputs:
+    description: Specifies quadrature counter enable bits.
+    bits:
+      EncoderPort2: 0x4
+  FrameAcquired:
+    description: Specifies that camera frame was acquired.
+    bits:
+      FrameAcquired: 0x1
+groupMasks:
+  MimicOutput:
+    description: Specifies the target IO on which to mimic the specified register.
+    values:
+      None: 0
+      DIO0: 1
+      DIO1: 2
+      DIO2: 3
+      DO0: 4
+      DO1: 5
+      DO2: 6
+      DO3: 7      
+  


### PR DESCRIPTION
This PR adds the first draft of the Behavior device metadata file, together with the corresponding auto-generated Bonsai high-level interface. The metadata YML file makes use of merge operators to avoid repeating declarations as much as possible, and currently relies on bitmask values to represent digital input and output port state.