### PR TITLE
Update interface with new encoder mode register and private registers

### DIFF
--- a/Generators/Generators.csproj
+++ b/Generators/Generators.csproj
@@ -15,7 +15,7 @@
     <FirmwarePath>..\Firmware\Harp.Behavior</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Harp.Generators" Version="0.1.0" GeneratePathProperty="true" />
+    <PackageReference Include="Harp.Generators" Version="0.2.0" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>

--- a/Interface/Harp.Behavior/AsyncDevice.Generated.cs
+++ b/Interface/Harp.Behavior/AsyncDevice.Generated.cs
@@ -2304,6 +2304,52 @@ namespace Harp.Behavior
         }
 
         /// <summary>
+        /// Asynchronously reads the contents of the EncoderMode register.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<EncoderModeConfig> ReadEncoderModeAsync(CancellationToken cancellationToken = default)
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EncoderMode.Address), cancellationToken);
+            return EncoderMode.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the EncoderMode register.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<EncoderModeConfig>> ReadTimestampedEncoderModeAsync(CancellationToken cancellationToken = default)
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(EncoderMode.Address), cancellationToken);
+            return EncoderMode.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the EncoderMode register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteEncoderModeAsync(EncoderModeConfig value, CancellationToken cancellationToken = default)
+        {
+            var request = EncoderMode.FromPayload(MessageType.Write, value);
+            await CommandAsync(request, cancellationToken);
+        }
+
+        /// <summary>
         /// Asynchronously reads the contents of the Camera0Frame register.
         /// </summary>
         /// <param name="cancellationToken">

--- a/Interface/Harp.Behavior/Device.Generated.cs
+++ b/Interface/Harp.Behavior/Device.Generated.cs
@@ -38,6 +38,7 @@ namespace Harp.Behavior
             (Bonsai.Harp.Device.RegisterMap.ToDictionary(entry => entry.Key, entry => entry.Value))
         {
             { 32, typeof(DigitalInputState) },
+            { 33, typeof(Reserved0) },
             { 34, typeof(OutputSet) },
             { 35, typeof(OutputClear) },
             { 36, typeof(OutputToggle) },
@@ -88,22 +89,44 @@ namespace Harp.Behavior
             { 81, typeof(DisableServos) },
             { 82, typeof(EnableEncoders) },
             { 83, typeof(EncoderMode) },
+            { 84, typeof(Reserved2) },
+            { 85, typeof(Reserved3) },
+            { 86, typeof(Reserved4) },
+            { 87, typeof(Reserved5) },
+            { 88, typeof(Reserved6) },
+            { 89, typeof(Reserved7) },
+            { 90, typeof(Reserved8) },
+            { 91, typeof(Reserved9) },
             { 92, typeof(Camera0Frame) },
             { 93, typeof(Camera0Frequency) },
             { 94, typeof(Camera1Frame) },
             { 95, typeof(Camera1Frequency) },
+            { 96, typeof(Reserved10) },
+            { 97, typeof(Reserved11) },
+            { 98, typeof(Reserved12) },
+            { 99, typeof(Reserved13) },
             { 100, typeof(ServoMotor2Period) },
             { 101, typeof(ServoMotor2Pulse) },
             { 102, typeof(ServoMotor3Period) },
             { 103, typeof(ServoMotor3Pulse) },
+            { 104, typeof(Reserved14) },
+            { 105, typeof(Reserved15) },
+            { 106, typeof(Reserved16) },
+            { 107, typeof(Reserved17) },
             { 108, typeof(EncoderReset) },
+            { 109, typeof(Reserved18) },
             { 110, typeof(EnableSerialTimestamp) },
             { 111, typeof(MimicPort0IR) },
             { 112, typeof(MimicPort1IR) },
             { 113, typeof(MimicPort2IR) },
+            { 114, typeof(Reserved20) },
+            { 115, typeof(Reserved21) },
+            { 116, typeof(Reserved22) },
             { 117, typeof(MimicPort0Valve) },
             { 118, typeof(MimicPort1Valve) },
             { 119, typeof(MimicPort2Valve) },
+            { 120, typeof(Reserved23) },
+            { 121, typeof(Reserved24) },
             { 122, typeof(PokeInputFilter) }
         };
     }
@@ -757,6 +780,28 @@ namespace Harp.Behavior
         {
             return DigitalInputState.GetTimestampedPayload(message);
         }
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved0
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 33;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
     }
 
     /// <summary>
@@ -5666,6 +5711,182 @@ namespace Harp.Behavior
     }
 
     /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved2
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved2"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 84;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved2"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved2"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved3
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved3"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 85;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved3"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved3"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved4
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved4"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 86;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved4"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved4"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved5
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved5"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 87;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved5"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved5"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved6
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved6"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 88;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved6"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved6"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved7
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved7"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 89;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved7"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved7"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved8
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved8"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 90;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved8"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved8"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved9
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved9"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 91;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved9"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved9"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
     /// Represents a register that specifies that a frame was acquired on camera 0.
     /// </summary>
     [Description("Specifies that a frame was acquired on camera 0.")]
@@ -6049,6 +6270,94 @@ namespace Harp.Behavior
         {
             return Camera1Frequency.GetTimestampedPayload(message);
         }
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved10
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved10"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 96;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved10"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved10"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved11
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved11"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 97;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved11"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved11"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved12
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved12"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 98;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved12"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved12"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved13
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved13"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 99;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved13"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved13"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
     }
 
     /// <summary>
@@ -6436,6 +6745,94 @@ namespace Harp.Behavior
     }
 
     /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved14
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved14"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 104;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved14"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved14"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved15
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved15"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 105;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved15"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved15"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved16
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved16"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 106;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved16"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved16"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved17
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved17"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 107;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved17"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved17"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
     /// Represents a register that reset the counter of the specified encoders to zero.
     /// </summary>
     [Description("Reset the counter of the specified encoders to zero.")]
@@ -6530,6 +6927,28 @@ namespace Harp.Behavior
         {
             return EncoderReset.GetTimestampedPayload(message);
         }
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved18
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved18"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 109;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved18"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved18"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
     }
 
     /// <summary>
@@ -6920,6 +7339,72 @@ namespace Harp.Behavior
     }
 
     /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved20
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved20"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 114;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved20"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved20"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved21
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved21"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 115;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved21"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved21"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved22
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved22"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 116;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved22"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved22"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
     /// Represents a register that specifies the digital output to mimic the Port 0 valve state.
     /// </summary>
     [Description("Specifies the digital output to mimic the Port 0 valve state.")]
@@ -7208,6 +7693,50 @@ namespace Harp.Behavior
         {
             return MimicPort2Valve.GetTimestampedPayload(message);
         }
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved23
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved23"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 120;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved23"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved23"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+    }
+
+    /// <summary>
+    /// Represents a register that reserved for future use.
+    /// </summary>
+    [Description("Reserved for future use")]
+    internal partial class Reserved24
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Reserved24"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 121;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Reserved24"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Reserved24"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
     }
 
     /// <summary>

--- a/Interface/Harp.Behavior/Device.Generated.cs
+++ b/Interface/Harp.Behavior/Device.Generated.cs
@@ -87,6 +87,7 @@ namespace Harp.Behavior
             { 80, typeof(EnableServos) },
             { 81, typeof(DisableServos) },
             { 82, typeof(EnableEncoders) },
+            { 83, typeof(EncoderMode) },
             { 92, typeof(Camera0Frame) },
             { 93, typeof(Camera0Frequency) },
             { 94, typeof(Camera1Frame) },
@@ -182,6 +183,7 @@ namespace Harp.Behavior
     /// <seealso cref="EnableServos"/>
     /// <seealso cref="DisableServos"/>
     /// <seealso cref="EnableEncoders"/>
+    /// <seealso cref="EncoderMode"/>
     /// <seealso cref="Camera0Frame"/>
     /// <seealso cref="Camera0Frequency"/>
     /// <seealso cref="Camera1Frame"/>
@@ -249,6 +251,7 @@ namespace Harp.Behavior
     [XmlInclude(typeof(EnableServos))]
     [XmlInclude(typeof(DisableServos))]
     [XmlInclude(typeof(EnableEncoders))]
+    [XmlInclude(typeof(EncoderMode))]
     [XmlInclude(typeof(Camera0Frame))]
     [XmlInclude(typeof(Camera0Frequency))]
     [XmlInclude(typeof(Camera1Frame))]
@@ -337,6 +340,7 @@ namespace Harp.Behavior
     /// <seealso cref="EnableServos"/>
     /// <seealso cref="DisableServos"/>
     /// <seealso cref="EnableEncoders"/>
+    /// <seealso cref="EncoderMode"/>
     /// <seealso cref="Camera0Frame"/>
     /// <seealso cref="Camera0Frequency"/>
     /// <seealso cref="Camera1Frame"/>
@@ -404,6 +408,7 @@ namespace Harp.Behavior
     [XmlInclude(typeof(EnableServos))]
     [XmlInclude(typeof(DisableServos))]
     [XmlInclude(typeof(EnableEncoders))]
+    [XmlInclude(typeof(EncoderMode))]
     [XmlInclude(typeof(Camera0Frame))]
     [XmlInclude(typeof(Camera0Frequency))]
     [XmlInclude(typeof(Camera1Frame))]
@@ -471,6 +476,7 @@ namespace Harp.Behavior
     [XmlInclude(typeof(TimestampedEnableServos))]
     [XmlInclude(typeof(TimestampedDisableServos))]
     [XmlInclude(typeof(TimestampedEnableEncoders))]
+    [XmlInclude(typeof(TimestampedEncoderMode))]
     [XmlInclude(typeof(TimestampedCamera0Frame))]
     [XmlInclude(typeof(TimestampedCamera0Frequency))]
     [XmlInclude(typeof(TimestampedCamera1Frame))]
@@ -556,6 +562,7 @@ namespace Harp.Behavior
     /// <seealso cref="EnableServos"/>
     /// <seealso cref="DisableServos"/>
     /// <seealso cref="EnableEncoders"/>
+    /// <seealso cref="EncoderMode"/>
     /// <seealso cref="Camera0Frame"/>
     /// <seealso cref="Camera0Frequency"/>
     /// <seealso cref="Camera1Frame"/>
@@ -623,6 +630,7 @@ namespace Harp.Behavior
     [XmlInclude(typeof(EnableServos))]
     [XmlInclude(typeof(DisableServos))]
     [XmlInclude(typeof(EnableEncoders))]
+    [XmlInclude(typeof(EncoderMode))]
     [XmlInclude(typeof(Camera0Frame))]
     [XmlInclude(typeof(Camera0Frequency))]
     [XmlInclude(typeof(Camera1Frame))]
@@ -5561,6 +5569,103 @@ namespace Harp.Behavior
     }
 
     /// <summary>
+    /// Represents a register that configures the operation mode of the quadrature encoders.
+    /// </summary>
+    [Description("Configures the operation mode of the quadrature encoders.")]
+    public partial class EncoderMode
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EncoderMode"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 83;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="EncoderMode"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="EncoderMode"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="EncoderMode"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static EncoderModeConfig GetPayload(HarpMessage message)
+        {
+            return (EncoderModeConfig)message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="EncoderMode"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<EncoderModeConfig> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((EncoderModeConfig)payload.Value, payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="EncoderMode"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EncoderMode"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, EncoderModeConfig value)
+        {
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="EncoderMode"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="EncoderMode"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, EncoderModeConfig value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// EncoderMode register.
+    /// </summary>
+    /// <seealso cref="EncoderMode"/>
+    [Description("Filters and selects timestamped messages from the EncoderMode register.")]
+    public partial class TimestampedEncoderMode
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="EncoderMode"/> register. This field is constant.
+        /// </summary>
+        public const int Address = EncoderMode.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="EncoderMode"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<EncoderModeConfig> GetPayload(HarpMessage message)
+        {
+            return EncoderMode.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
     /// Represents a register that specifies that a frame was acquired on camera 0.
     /// </summary>
     [Description("Specifies that a frame was acquired on camera 0.")]
@@ -7255,6 +7360,7 @@ namespace Harp.Behavior
     /// <seealso cref="CreateEnableServosPayload"/>
     /// <seealso cref="CreateDisableServosPayload"/>
     /// <seealso cref="CreateEnableEncodersPayload"/>
+    /// <seealso cref="CreateEncoderModePayload"/>
     /// <seealso cref="CreateCamera0FramePayload"/>
     /// <seealso cref="CreateCamera0FrequencyPayload"/>
     /// <seealso cref="CreateCamera1FramePayload"/>
@@ -7322,6 +7428,7 @@ namespace Harp.Behavior
     [XmlInclude(typeof(CreateEnableServosPayload))]
     [XmlInclude(typeof(CreateDisableServosPayload))]
     [XmlInclude(typeof(CreateEnableEncodersPayload))]
+    [XmlInclude(typeof(CreateEncoderModePayload))]
     [XmlInclude(typeof(CreateCamera0FramePayload))]
     [XmlInclude(typeof(CreateCamera0FrequencyPayload))]
     [XmlInclude(typeof(CreateCamera1FramePayload))]
@@ -7389,6 +7496,7 @@ namespace Harp.Behavior
     [XmlInclude(typeof(CreateTimestampedEnableServosPayload))]
     [XmlInclude(typeof(CreateTimestampedDisableServosPayload))]
     [XmlInclude(typeof(CreateTimestampedEnableEncodersPayload))]
+    [XmlInclude(typeof(CreateTimestampedEncoderModePayload))]
     [XmlInclude(typeof(CreateTimestampedCamera0FramePayload))]
     [XmlInclude(typeof(CreateTimestampedCamera0FrequencyPayload))]
     [XmlInclude(typeof(CreateTimestampedCamera1FramePayload))]
@@ -10259,6 +10367,60 @@ namespace Harp.Behavior
 
     /// <summary>
     /// Represents an operator that creates a message payload
+    /// that configures the operation mode of the quadrature encoders.
+    /// </summary>
+    [DisplayName("EncoderModePayload")]
+    [Description("Creates a message payload that configures the operation mode of the quadrature encoders.")]
+    public partial class CreateEncoderModePayload
+    {
+        /// <summary>
+        /// Gets or sets the value that configures the operation mode of the quadrature encoders.
+        /// </summary>
+        [Description("The value that configures the operation mode of the quadrature encoders.")]
+        public EncoderModeConfig EncoderMode { get; set; }
+
+        /// <summary>
+        /// Creates a message payload for the EncoderMode register.
+        /// </summary>
+        /// <returns>The created message payload value.</returns>
+        public EncoderModeConfig GetPayload()
+        {
+            return EncoderMode;
+        }
+
+        /// <summary>
+        /// Creates a message that configures the operation mode of the quadrature encoders.
+        /// </summary>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the EncoderMode register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
+        {
+            return Harp.Behavior.EncoderMode.FromPayload(messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a timestamped message payload
+    /// that configures the operation mode of the quadrature encoders.
+    /// </summary>
+    [DisplayName("TimestampedEncoderModePayload")]
+    [Description("Creates a timestamped message payload that configures the operation mode of the quadrature encoders.")]
+    public partial class CreateTimestampedEncoderModePayload : CreateEncoderModePayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that configures the operation mode of the quadrature encoders.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the EncoderMode register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Harp.Behavior.EncoderMode.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies that a frame was acquired on camera 0.
     /// </summary>
     [DisplayName("Camera0FramePayload")]
@@ -10488,8 +10650,10 @@ namespace Harp.Behavior
         /// <summary>
         /// Gets or sets the value that specifies the period of the servo motor in DO2, in microseconds.
         /// </summary>
+        [Range(min: 2, max: 65534)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
         [Description("The value that specifies the period of the servo motor in DO2, in microseconds.")]
-        public ushort ServoMotor2Period { get; set; }
+        public ushort ServoMotor2Period { get; set; } = 2;
 
         /// <summary>
         /// Creates a message payload for the ServoMotor2Period register.
@@ -10542,8 +10706,10 @@ namespace Harp.Behavior
         /// <summary>
         /// Gets or sets the value that specifies the pulse of the servo motor in DO2, in microseconds.
         /// </summary>
+        [Range(min: 6, max: 65530)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
         [Description("The value that specifies the pulse of the servo motor in DO2, in microseconds.")]
-        public ushort ServoMotor2Pulse { get; set; }
+        public ushort ServoMotor2Pulse { get; set; } = 6;
 
         /// <summary>
         /// Creates a message payload for the ServoMotor2Pulse register.
@@ -10596,8 +10762,10 @@ namespace Harp.Behavior
         /// <summary>
         /// Gets or sets the value that specifies the period of the servo motor in DO3, in microseconds.
         /// </summary>
+        [Range(min: 2, max: 65534)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
         [Description("The value that specifies the period of the servo motor in DO3, in microseconds.")]
-        public ushort ServoMotor3Period { get; set; }
+        public ushort ServoMotor3Period { get; set; } = 2;
 
         /// <summary>
         /// Creates a message payload for the ServoMotor3Period register.
@@ -10650,8 +10818,10 @@ namespace Harp.Behavior
         /// <summary>
         /// Gets or sets the value that specifies the pulse of the servo motor in DO3, in microseconds.
         /// </summary>
+        [Range(min: 6, max: 65530)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
         [Description("The value that specifies the pulse of the servo motor in DO3, in microseconds.")]
-        public ushort ServoMotor3Pulse { get; set; }
+        public ushort ServoMotor3Pulse { get; set; } = 6;
 
         /// <summary>
         /// Creates a message payload for the ServoMotor3Pulse register.
@@ -11444,5 +11614,14 @@ namespace Harp.Behavior
         DO1 = 5,
         DO2 = 6,
         DO3 = 7
+    }
+
+    /// <summary>
+    /// Specifies the type of reading made from the quadrature encoder.
+    /// </summary>
+    public enum EncoderModeConfig : byte
+    {
+        Position = 0,
+        Displacement = 1
     }
 }

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This PR updates the generator package and regenerates the interface to emit both the new encoder mode register and all reserved private registers as internal classes. This will avoid crashing `GroupByRegister` when grabbing register dumps.