### PR TITLE
Include device metadata file as embedded resource

### DIFF
--- a/Interface/Harp.Behavior/DeviceMetadata.cs
+++ b/Interface/Harp.Behavior/DeviceMetadata.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace Harp.Behavior
+{
+    /// <summary>
+    /// Represents an operator that returns the contents of the metadata file
+    /// describing the device registers.
+    /// </summary>
+    [Description("Returns the contents of the metadata file describing the device registers.")]
+    public class DeviceMetadata : Source<string>
+    {
+        static readonly string Metadata = GetDeviceMetadata();
+
+        static string GetDeviceMetadata()
+        {
+            var metadataType = typeof(DeviceMetadata);
+            using var metadataStream = metadataType.Assembly.GetManifestResourceStream($"{metadataType.Namespace}.device.yml");
+            using var streamReader = new StreamReader(metadataStream);
+            return streamReader.ReadToEnd();
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<string> Generate()
+        {
+            return Observable.Return(Metadata);
+        }
+    }
+}

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -18,7 +18,7 @@
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>build240401</VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Content Include="..\LICENSE" PackagePath="/" />
     <Content Include="..\icon.png" PackagePath="/" />
+    <EmbeddedResource Include="..\..\device.yml" />
   </ItemGroup>
 
 </Project>

--- a/Interface/Harp.Behavior/Properties/launchSettings.json
+++ b/Interface/Harp.Behavior/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/device.yml
+++ b/device.yml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/harp-tech/reflex-generator/main/schema/device.json
+# yaml-language-server: $schema=https://harp-tech.org/draft-02/schema/device.json
 device: Behavior
 whoAmI: 1216
 firmwareVersion: "3.2"


### PR DESCRIPTION
Following discussions around https://github.com/harp-tech/protocol/issues/41 this PR proposes an implementation for embedding device metadata in the interface package itself.

If adopted, this would allow implementing a standard logging format where all registers are stored grouped by register address and the device metadata could be saved directly using `WriteAllText` into the same folder.