### PR TITLE
Include device metadata file as embedded resource

### DIFF
--- a/Generators/Generators.csproj
+++ b/Generators/Generators.csproj
@@ -15,7 +15,7 @@
     <FirmwarePath>..\Firmware\Harp.Behavior</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Harp.Generators" Version="0.2.0" GeneratePathProperty="true" />
+    <PackageReference Include="Harp.Generators" Version="0.3.0" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>

--- a/Interface/Harp.Behavior/Device.Generated.cs
+++ b/Interface/Harp.Behavior/Device.Generated.cs
@@ -129,6 +129,41 @@ namespace Harp.Behavior
             { 121, typeof(Reserved24) },
             { 122, typeof(PokeInputFilter) }
         };
+
+        /// <summary>
+        /// Gets the contents of the metadata file describing the <see cref="Behavior"/>
+        /// device registers.
+        /// </summary>
+        public static readonly string Metadata = GetDeviceMetadata();
+
+        static string GetDeviceMetadata()
+        {
+            var deviceType = typeof(Device);
+            using var metadataStream = deviceType.Assembly.GetManifestResourceStream($"{deviceType.Namespace}.device.yml");
+            using var streamReader = new System.IO.StreamReader(metadataStream);
+            return streamReader.ReadToEnd();
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that returns the contents of the metadata file
+    /// describing the <see cref="Behavior"/> device registers.
+    /// </summary>
+    [Description("Returns the contents of the metadata file describing the Behavior device registers.")]
+    public partial class GetMetadata : Source<string>
+    {
+        /// <summary>
+        /// Returns an observable sequence with the contents of the metadata file
+        /// describing the <see cref="Behavior"/> device registers.
+        /// </summary>
+        /// <returns>
+        /// A sequence with a single <see cref="string"/> object representing the
+        /// contents of the metadata file.
+        /// </returns>
+        public override IObservable<string> Generate()
+        {
+            return Observable.Return(Device.Metadata);
+        }
     }
 
     /// <summary>
@@ -5226,9 +5261,9 @@ namespace Harp.Behavior
     }
 
     /// <summary>
-    /// Represents a register that specifies the camera outputs to disable in the device.
+    /// Represents a register that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.
     /// </summary>
-    [Description("Specifies the camera outputs to disable in the device.")]
+    [Description("Specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.")]
     public partial class StopCameras
     {
         /// <summary>
@@ -10680,16 +10715,16 @@ namespace Harp.Behavior
 
     /// <summary>
     /// Represents an operator that creates a message payload
-    /// that specifies the camera outputs to disable in the device.
+    /// that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.
     /// </summary>
     [DisplayName("StopCamerasPayload")]
-    [Description("Creates a message payload that specifies the camera outputs to disable in the device.")]
+    [Description("Creates a message payload that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.")]
     public partial class CreateStopCamerasPayload
     {
         /// <summary>
-        /// Gets or sets the value that specifies the camera outputs to disable in the device.
+        /// Gets or sets the value that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.
         /// </summary>
-        [Description("The value that specifies the camera outputs to disable in the device.")]
+        [Description("The value that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.")]
         public CameraOutputs StopCameras { get; set; }
 
         /// <summary>
@@ -10702,7 +10737,7 @@ namespace Harp.Behavior
         }
 
         /// <summary>
-        /// Creates a message that specifies the camera outputs to disable in the device.
+        /// Creates a message that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.
         /// </summary>
         /// <param name="messageType">Specifies the type of the created message.</param>
         /// <returns>A new message for the StopCameras register.</returns>
@@ -10714,14 +10749,14 @@ namespace Harp.Behavior
 
     /// <summary>
     /// Represents an operator that creates a timestamped message payload
-    /// that specifies the camera outputs to disable in the device.
+    /// that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.
     /// </summary>
     [DisplayName("TimestampedStopCamerasPayload")]
-    [Description("Creates a timestamped message payload that specifies the camera outputs to disable in the device.")]
+    [Description("Creates a timestamped message payload that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.")]
     public partial class CreateTimestampedStopCamerasPayload : CreateStopCamerasPayload
     {
         /// <summary>
-        /// Creates a timestamped message that specifies the camera outputs to disable in the device.
+        /// Creates a timestamped message that specifies the camera outputs to disable in the device. An event will be issued when the trigger signal is actually stopped being generated.
         /// </summary>
         /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
         /// <param name="messageType">Specifies the type of the created message.</param>
@@ -11913,6 +11948,23 @@ namespace Harp.Behavior
         /// The voltage at the output of the ADC channel 1.
         /// </summary>
         public short AnalogInput1;
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the payload of
+        /// the AnalogData register.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the payload of the
+        /// AnalogData register.
+        /// </returns>
+        public override string ToString()
+        {
+            return "AnalogDataPayload { " +
+                "AnalogInput0 = " + AnalogInput0 + ", " +
+                "Encoder = " + Encoder + ", " +
+                "AnalogInput1 = " + AnalogInput1 + " " +
+            "}";
+        }
     }
 
     /// <summary>
@@ -11974,6 +12026,26 @@ namespace Harp.Behavior
         /// The intensity of the blue channel in the RGB1 LED.
         /// </summary>
         public byte Blue1;
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the payload of
+        /// the RgbAll register.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the payload of the
+        /// RgbAll register.
+        /// </returns>
+        public override string ToString()
+        {
+            return "RgbAllPayload { " +
+                "Green0 = " + Green0 + ", " +
+                "Red0 = " + Red0 + ", " +
+                "Blue0 = " + Blue0 + ", " +
+                "Green1 = " + Green1 + ", " +
+                "Red1 = " + Red1 + ", " +
+                "Blue1 = " + Blue1 + " " +
+            "}";
+        }
     }
 
     /// <summary>
@@ -12011,6 +12083,23 @@ namespace Harp.Behavior
         /// The intensity of the blue channel in the RGB LED.
         /// </summary>
         public byte Blue;
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the payload of
+        /// the Rgb register.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the payload of the
+        /// Rgb register.
+        /// </returns>
+        public override string ToString()
+        {
+            return "RgbPayload { " +
+                "Green = " + Green + ", " +
+                "Red = " + Red + ", " +
+                "Blue = " + Blue + " " +
+            "}";
+        }
     }
 
     /// <summary>

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -18,7 +18,7 @@
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>build240401</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -18,7 +18,7 @@
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>build240401</VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Content Include="..\LICENSE" PackagePath="/" />
     <Content Include="..\icon.png" PackagePath="/" />
+    <EmbeddedResource Include="..\..\device.yml" />
   </ItemGroup>
 
 </Project>

--- a/Interface/Harp.Behavior/Properties/launchSettings.json
+++ b/Interface/Harp.Behavior/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/device.yml
+++ b/device.yml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/harp-tech/reflex-generator/main/schema/device.json
+# yaml-language-server: $schema=https://harp-tech.org/draft-02/schema/device.json
 device: Behavior
 whoAmI: 1216
 firmwareVersion: "3.2"


### PR DESCRIPTION
Building on discussions around https://github.com/harp-tech/protocol/issues/41 and https://github.com/harp-tech/reflex-generator/pull/63, this PR updates the interface generators to support embedding device metadata in the interface package itself.

This allows implementing a standard logging format where all registers are stored grouped by register address and the device metadata could be saved directly using `WriteAllText` into the same folder.