### PR TITLE
Add README file to device package and remove unused csproj properties

### DIFF
--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Title>Harp - Behavior</Title>
     <Authors>harp-tech</Authors>
-    <Copyright>Copyright © harp-tech and Contributors 2023</Copyright>
+    <Copyright>Copyright © harp-tech and Contributors</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
@@ -12,8 +11,7 @@
     <PackageType>Dependency;BonsaiLibrary</PackageType>
     <PackageTags>Harp Behavior Bonsai Rx</PackageTags>
     <PackageProjectUrl>https://harp-tech.org</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/harp-tech/device.behavior.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>

--- a/Interface/Harp.Behavior/Harp.Behavior.csproj
+++ b/Interface/Harp.Behavior/Harp.Behavior.csproj
@@ -14,6 +14,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.3.0</VersionPrefix>
@@ -26,9 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\LICENSE" PackagePath="/" />
-    <Content Include="..\icon.png" PackagePath="/" />
-    <EmbeddedResource Include="..\..\device.yml" />
+    <None Include="$(ProjectDir)$(PackageReadmeFile)" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\$(PackageLicenseFile)" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\$(PackageIcon)" Pack="true" PackagePath="/" Visible="false" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\device.yml" />
   </ItemGroup>
 
 </Project>

--- a/Interface/Harp.Behavior/README.md
+++ b/Interface/Harp.Behavior/README.md
@@ -1,0 +1,15 @@
+## About
+
+`Harp.Behavior` provides operators for data acquisition and control of [Harp Behavior](https://harp-tech.org/api/Harp.Behavior.html) devices in the [Bonsai](https://bonsai-rx.org) visual reactive programming language.
+
+## How to Use
+
+To use `Harp.Behavior` for visual reactive programming, please install this package using the [Bonsai package manager](https://bonsai-rx.org/docs/articles/packages.html).
+
+## Additional Documentation
+
+For additional documentation and examples, refer to the [official Harp documentation](https://harp-tech.org/api/Harp.Behavior.html).
+
+## Feedback & Contributing
+
+`Harp.Behavior` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/harp-tech/device.behavior).

--- a/Interface/LICENSE
+++ b/Interface/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2023 harp-tech and Contributors
+Copyright (C) harp-tech and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
To improve package discoverability and understanding we embed a README file directly in the device package. We also simplify a few properties in the project file and remove date range from interface copyright statement.