### PR TITLE
Remove BOM from generated interface file

### DIFF
--- a/Interface/Harp.Behavior/Device.Generated.cs
+++ b/Interface/Harp.Behavior/Device.Generated.cs
@@ -1,4 +1,4 @@
-﻿using Bonsai;
+using Bonsai;
 using Bonsai.Harp;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
This avoids conflict with the CI/CD pipeline in #26. In the future we may want to remove the BOM from all source files.